### PR TITLE
refactor: error handling with thiserror, anyhow for runtime only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/homestar-core"
     commit-message:
-      prefix: "chore"
+      prefix: "[chore(core)]"
       include: "scope"
     target-branch: "main"
     schedule:
@@ -18,7 +18,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/homestar-runtime"
     commit-message:
-      prefix: "chore"
+      prefix: "[chore(runtime)]"
       include: "scope"
     target-branch: "main"
     schedule:
@@ -27,7 +27,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/homestar-guest-wasm"
     commit-message:
-      prefix: "chore"
+      prefix: "[chore(guest-wasm)]"
       include: "scope"
     target-branch: "main"
     schedule:
@@ -36,7 +36,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/homestar-wasm"
     commit-message:
-      prefix: "chore"
+      prefix: "[chore(wasm)]"
       include: "scope"
     target-branch: "main"
     schedule:
@@ -45,7 +45,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "[chore(ci)]"
       include: "scope"
     target-branch: "main"
     schedule:

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,16 @@
+# cargo-watch ignores
+
+docker
+flake.lock
+release-please-config.json
+deny.toml
+diesel.toml
+LICENSE
+*.nix
+*.md
+
+.envrc
+.dockerignore
+.gitignore
+.release-please-manifest.json
+.pre-commit-config.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2580,6 +2580,7 @@ dependencies = [
  "enum-assoc",
  "generic-array",
  "indexmap",
+ "json",
  "libipld",
  "libsqlite3-sys",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.66.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
+thiserror = "1.0"
 tokio = { version = "1.26", features = ["fs", "io-util", "io-std", "macros", "rt", "rt-multi-thread"] }
 tracing = "0.1"
 

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ represents the `homestar` runtime.
 
 - Running the tests:
 
-We recommend using [cargo nextest][cargo-nextest], which is installed via
-[our Nix flake](#nix) or can be [installed separately][cargo-nextest-install].
+We recommend using [cargo nextest][cargo-nextest], which is installed by default
+in our [Nix flake](#nix) or can be [installed separately][cargo-nextest-install].
 
   ```console
   cargo nextest run --all-features --no-capture
   ```
 
-Otherwise, the above command looks like this using the default `cargo test`:
+The above command translates to this using the default `cargo test`:
 
   ```console
   cargo test --all-features -- --nocapture
@@ -105,7 +105,7 @@ with `experimental` and `buildkit` set to `true`, for example:
 - Build a multi-plaform Docker image via [buildx][buildx]:
 
   ```console
-  docker buildx build --platform=linux/amd64,linux/arm64 -t homestar-runtime --progress=plain .
+  docker buildx build --file docker/Dockerfile --platform=linux/amd64,linux/arm64 -t homestar-runtime --progress=plain .
   ```
 
 - Run a Docker image (depending on your platform):
@@ -149,8 +149,27 @@ hooks. Please run this before every commit and/or push.
 
 - We recommend leveraging [cargo-watch][cargo-watch],
   [cargo-expand][cargo-expand] and [irust][irust] for Rust development.
-- We also recommend using [cargo-udeps][cargo-udeps] for removing unused dependencies
-  before commits and pull-requests.
+- We also recommend using [cargo-udeps][cargo-udeps] for removing unused
+  dependencies before commits and pull-requests.
+- If using our [Nix flake][nix-flake], there are a number of handy
+  command shortcuts available for working with `cargo-watch`, `diesel`, and
+  other binaries, including:
+  * `ci`, which runs a sequence of commands to check formatting, lints, release
+    builds, and tests
+  * `db` and `db-reset` for running `diesel` setup and migrations
+  * `compile-wasm` for compiling [homestar-guest-wasm](./homestar-guest-wasm),
+    a [wit-bindgen][]-driven example, to the `wasm32-unknown-unknown` target
+  * `docker-<amd64,arm64>` for running docker builds
+  * `nx-test`, which translates to `cargo nextest run && cargo test --doc`
+  * `x-test` for testing continuously as files change, translating to
+    `cargo watch -c -s "cargo nextest run && cargo test --doc"`
+  * `x-<build,check,run,clippy>` for running a variety of `cargo watch`
+    execution stages
+  * `nx-test-<all,0>`, which is just like `nx-test`, but adds `all` or `0`
+    for running tests either with the `all-features` flag or
+    `no-default-features` flag, respectively.
+  * `x-<build,check,run,clippy,test>-<core,wasm,runtime>` for package-specific
+    builds, tests, etc.
 
 ### Conventional Commits
 
@@ -221,3 +240,4 @@ conditions.
 [pre-commit]: https://pre-commit.com/
 [seamless-services]: https://youtu.be/Kr3B3sXh_VA
 [ucan-invocation]: https://github.com/ucan-wg/invocation
+[wit-bindgen]: https://github.com/bytecodealliance/wit-bindgen

--- a/README.md
+++ b/README.md
@@ -12,20 +12,32 @@
     <a href="https://crates.io/crates/homestar-wasm">
       <img src="https://img.shields.io/crates/v/homestar-wasm?label=crates" alt="Crate">
     </a>
+    <a href="https://crates.io/crates/homestar-runtime">
+      <img src="https://img.shields.io/crates/v/homestar-runtime?label=crates" alt="Crate">
+    </a>
     <a href="https://codecov.io/gh/ipvm-wg/homestar">
       <img src="https://codecov.io/gh/ipvm-wg/homestar/branch/main/graph/badge.svg?token=SOMETOKEN" alt="Code Coverage"/>
     </a>
-    <a href="https://github.com/ipvm-wg/homestar/actions?query=">
-      <img src="https://github.com/ipvm-wg/homestar/actions/workflows/tests_and_checks.yml/badge.svg" alt="Build Status">
+    <a href="https://github.com/ipvm-wg/homestar/actions/workflows/tests_and_checks.yml">
+      <img src="https://github.com/ipvm-wg/homestar/actions/workflows/tests_and_checks.yml/badge.svg" alt="Tests and Checks Status">
+    </a>
+    <a href="https://github.com/ipvm-wg/homestar/actions/workflows/docker.yml">
+      <img src="https://github.com/ipvm-wg/homestar/actions/workflows/docker.yml/badge.svg" alt="Build Docker Status">
+    </a>
+    <a href="https://github.com/ipvm-wg/homestar/actions/workflows/audit.yml">
+      <img src="https://github.com/ipvm-wg/homestar/actions/workflows/audit.yml/badge.svg" alt="Cargo Audit Status">
     </a>
     <a href="https://github.com/ipvm-wg/homestar/blob/main/LICENSE">
       <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
     </a>
     <a href="https://docs.rs/homestar-core">
-      <img src="https://img.shields.io/static/v1?label=Docs&message=core.docs.rs&color=blue" alt="Docs">
+      <img src="https://img.shields.io/static/v1?label=Docs&message=core.docs.rs&color=pink" alt="Docs">
     </a>
     <a href="https://docs.rs/homestar-wasm">
-      <img src="https://img.shields.io/static/v1?label=Docs&message=wasm.docs.rs&color=blue" alt="Docs">
+      <img src="https://img.shields.io/static/v1?label=Docs&message=wasm.docs.rs&color=pink" alt="Docs">
+    </a>
+    <a href="https://docs.rs/homestar-runtime">
+      <img src="https://img.shields.io/static/v1?label=Docs&message=runtime.docs.rs&color=pink" alt="Docs">
     </a>
     <a href="https://discord.gg/fissioncodes">
       <img src="https://img.shields.io/static/v1?label=Discord&message=join%20us!&color=mediumslateblue" alt="Discord">

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -17,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1686331006,
+        "narHash": "sha256-hElRDWUNG655aqF0awu+h5cmDN+I/dQcChRt2tGuGGU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "85bcb95aa83be667e562e781e9d186c57a07d757",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "type": "indirect"
       }
     },
@@ -47,16 +50,31 @@
         ]
       },
       "locked": {
-        "lastModified": 1674095406,
-        "narHash": "sha256-RexH/1rZTiX4OhdYkuJP3MuANJ+JRgoLKL60iHm//T0=",
+        "lastModified": 1686537156,
+        "narHash": "sha256-mJD80brS6h6P4jzwdKID0S9RvfyiruxgJbXvPPIDqF0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5f7315b9800e2e500e6834767a57e39f7dbfd495",
+        "rev": "e75da5cfc7da874401decaa88f4ccb3b4d64d20d",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/homestar-core/Cargo.toml
+++ b/homestar-core/Cargo.toml
@@ -32,7 +32,7 @@ libsqlite3-sys = { version = "0.26", features = ["bundled"] }
 proptest = { version = "1.1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 signature = "2.0"
-thiserror = "1.0"
+thiserror = { workspace = true }
 tracing = { workspace = true }
 ucan = "0.1"
 url = "2.3"
@@ -40,6 +40,7 @@ xid = "1.0"
 
 [dev-dependencies]
 criterion = "0.4"
+json = "0.12"
 
 [features]
 default = []

--- a/homestar-core/src/consts.rs
+++ b/homestar-core/src/consts.rs
@@ -1,4 +1,6 @@
 //! Exported global constants.
 
-///  SemVer-formatted version of the UCAN Invocation Specification.
+/// SemVer-formatted version of the UCAN Invocation Specification.
 pub const INVOCATION_VERSION: &str = "0.2.0";
+/// DagCbor codec.
+pub const DAG_CBOR: u64 = 0x71;

--- a/homestar-core/src/lib.rs
+++ b/homestar-core/src/lib.rs
@@ -18,10 +18,13 @@
 //! [Ucan invocation]: <https://github.com/ucan-wg/invocation>
 
 pub mod consts;
+pub mod macros;
 #[cfg(any(test, feature = "test_utils"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "test_utils")))]
 pub mod test_utils;
 mod unit;
+
 pub mod workflow;
 pub use consts::*;
 pub use unit::*;
+pub use workflow::Workflow;

--- a/homestar-core/src/macros.rs
+++ b/homestar-core/src/macros.rs
@@ -1,0 +1,68 @@
+//! Macros for cross-crate export.
+
+/// Return early with an error.
+///
+/// Modelled after [anyhow::bail].
+///
+/// # Example
+///
+/// ```
+/// use homestar_core::{workflow, bail, Unit};
+///
+/// fn has_permission(user: usize, resource: usize) -> bool {
+///      true
+/// }
+///
+/// # fn main() -> Result<(), workflow::Error<Unit>> {
+/// #     let user = 0;
+/// #     let resource = 0;
+/// #
+///
+/// if !has_permission(user, resource) {
+///     bail!(workflow::Error::UnknownError);
+/// }
+///
+/// #     Ok(())
+/// # }
+/// ```
+#[macro_export]
+macro_rules! bail {
+    ($e:expr) => {
+        return Err($e);
+    };
+}
+
+/// /// Return early with an error if a condition is not satisfied.
+///
+/// Analogously to `assert!`, `ensure!` takes a condition and exits the function
+/// if the condition fails. Unlike `assert!`, `ensure!` returns an `Error`
+/// rather than panicking.
+///
+/// Modelled after [anyhow::ensure].
+///
+/// # Example
+///
+/// ```
+/// use homestar_core::{workflow, ensure, Unit};
+///
+/// #
+/// # fn main() -> Result<(), workflow::Error<Unit>> {
+/// #     let user = 1;
+/// #
+/// ensure!(
+///     user < 2,
+///     workflow::Error::ConditionNotMet(
+///         "only user 0 and 1 are allowed".to_string()
+///     )
+/// );
+/// #     Ok(())
+/// # }
+/// ```
+#[macro_export(local_inner_macros)]
+macro_rules! ensure {
+    ($cond:expr, $e:expr) => {
+        if !($cond) {
+            bail!($e);
+        }
+    };
+}

--- a/homestar-core/src/unit.rs
+++ b/homestar-core/src/unit.rs
@@ -4,10 +4,12 @@
 //! [Tasks]: crate::workflow::Task
 //! [Inputs]: crate::workflow::Input
 //! [Invocations]: crate::workflow::Invocation
+//!
 
 use crate::workflow::{
+    error::InputParseError,
     input::{self, Args, Parsed},
-    Input,
+    Error, Input,
 };
 use libipld::Ipld;
 
@@ -30,12 +32,18 @@ impl From<Ipld> for Unit {
 
 // Default implementation.
 impl input::Parse<Unit> for Input<Unit> {
-    fn parse(&self) -> anyhow::Result<Parsed<Unit>> {
+    fn parse(&self) -> Result<Parsed<Unit>, InputParseError<Unit>> {
         let args = match Ipld::try_from(self.to_owned())? {
             Ipld::List(v) => Ipld::List(v).try_into()?,
             ipld => Args::new(vec![ipld.try_into()?]),
         };
 
         Ok(Parsed::with(args))
+    }
+}
+
+impl From<Error<String>> for InputParseError<Unit> {
+    fn from(err: Error<String>) -> Self {
+        InputParseError::WorkflowError(err.into())
     }
 }

--- a/homestar-core/src/workflow.rs
+++ b/homestar-core/src/workflow.rs
@@ -2,8 +2,21 @@
 //!
 //! [Ucan invocation]: <https://github.com/ucan-wg/invocation>
 
+use self::Error as WorkflowError;
+use crate::{bail, Unit, DAG_CBOR};
+use libipld::{
+    cbor::DagCborCodec,
+    json::DagJsonCodec,
+    multihash::{Code, MultihashDigest},
+    prelude::Codec,
+    serde::from_ipld,
+    Cid, Ipld,
+};
+use std::collections::BTreeMap;
+
 mod ability;
 pub mod config;
+pub mod error;
 pub mod input;
 pub mod instruction;
 mod instruction_result;
@@ -16,6 +29,7 @@ pub mod receipt;
 pub mod task;
 
 pub use ability::*;
+pub use error::Error;
 pub use input::Input;
 pub use instruction::Instruction;
 pub use instruction_result::*;
@@ -26,9 +40,177 @@ pub use pointer::Pointer;
 pub use receipt::Receipt;
 pub use task::Task;
 
+const TASKS_KEY: &str = "tasks";
+
 /// Generic link, cid => T [IndexMap] for storing
 /// invoked, raw values in-memory and using them to
 /// resolve other steps within a runtime's workflow.
 ///
 /// [IndexMap]: indexmap::IndexMap
 pub type LinkMap<T> = indexmap::IndexMap<libipld::Cid, T>;
+
+/// Workflow composed of [tasks].
+///
+/// [tasks]: Task
+#[derive(Debug, Clone, PartialEq)]
+pub struct Workflow<'a, T> {
+    tasks: Vec<Task<'a, T>>,
+}
+
+impl<'a, T> Workflow<'a, T> {
+    /// Create a new [Workflow] given a set of tasks.
+    pub fn new(tasks: Vec<Task<'a, T>>) -> Self {
+        Self { tasks }
+    }
+
+    /// Return a [Workflow]'s [tasks] vector.
+    ///
+    /// [tasks]: Task
+    pub fn tasks(self) -> Vec<Task<'a, T>> {
+        self.tasks
+    }
+
+    /// Return a reference to [Workflow]'s [tasks] vector.
+    ///
+    /// [tasks]: Task
+    pub fn tasks_ref(&self) -> &Vec<Task<'a, T>> {
+        &self.tasks
+    }
+
+    /// Length of workflow given a series of [tasks].
+    ///
+    /// [tasks]: Task
+    pub fn len(&self) -> u32 {
+        self.tasks.len() as u32
+    }
+
+    /// Whether [Workflow] contains [tasks] or not.
+    ///
+    /// [tasks]: Task
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    /// Return workflow as stringified Json.
+    pub fn to_json(self) -> Result<String, WorkflowError<Unit>>
+    where
+        Ipld: From<Workflow<'a, T>>,
+    {
+        let encoded = DagJsonCodec.encode(&Ipld::from(self))?;
+        let s = std::str::from_utf8(&encoded)?;
+        Ok(s.to_string())
+    }
+}
+
+impl<'a, T> From<Workflow<'a, T>> for Ipld
+where
+    Ipld: From<Task<'a, T>>,
+{
+    fn from(workflow: Workflow<'a, T>) -> Self {
+        Ipld::Map(BTreeMap::from([(
+            TASKS_KEY.into(),
+            Ipld::List(
+                workflow
+                    .tasks
+                    .into_iter()
+                    .map(Ipld::from)
+                    .collect::<Vec<Ipld>>(),
+            ),
+        )]))
+    }
+}
+
+impl<'a, T> TryFrom<Ipld> for Workflow<'a, T>
+where
+    T: From<Ipld>,
+{
+    type Error = WorkflowError<Unit>;
+
+    fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
+        let map = from_ipld::<BTreeMap<String, Ipld>>(ipld)?;
+        let ipld = map
+            .get(TASKS_KEY)
+            .ok_or_else(|| WorkflowError::<Unit>::MissingFieldError(TASKS_KEY.to_string()))?;
+
+        let tasks = if let Ipld::List(tasks) = ipld {
+            tasks.iter().try_fold(vec![], |mut acc, ipld| {
+                acc.push(ipld.to_owned().try_into()?);
+                Ok::<_, Self::Error>(acc)
+            })?
+        } else {
+            bail!(WorkflowError::not_an_ipld_list());
+        };
+
+        Ok(Self { tasks })
+    }
+}
+
+impl<'a, T> TryFrom<Workflow<'a, T>> for Cid
+where
+    Ipld: From<Workflow<'a, T>>,
+{
+    type Error = WorkflowError<Unit>;
+
+    fn try_from(workflow: Workflow<'a, T>) -> Result<Self, Self::Error> {
+        let ipld: Ipld = workflow.into();
+        let bytes = DagCborCodec.encode(&ipld)?;
+        let hash = Code::Sha3_256.digest(&bytes);
+        Ok(Cid::new_v1(DAG_CBOR, hash))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        test_utils,
+        workflow::{config::Resources, instruction::RunInstruction, prf::UcanPrf},
+        Unit,
+    };
+
+    #[test]
+    fn workflow_to_json() {
+        let config = Resources::default();
+        let (instruction1, instruction2, _) =
+            test_utils::workflow::related_wasm_instructions::<Unit>();
+        let task1 = Task::new(
+            RunInstruction::Expanded(instruction1),
+            config.clone().into(),
+            UcanPrf::default(),
+        );
+        let task2 = Task::new(
+            RunInstruction::Expanded(instruction2),
+            config.into(),
+            UcanPrf::default(),
+        );
+
+        let workflow = Workflow::new(vec![task1.clone(), task2.clone()]);
+
+        let json_string = workflow.to_json().unwrap();
+
+        let json_val = json::from(json_string.clone());
+        assert_eq!(json_string, json_val.to_string());
+    }
+
+    #[test]
+    fn ipld_roundtrip_workflow() {
+        let config = Resources::default();
+        let (instruction1, instruction2, _) =
+            test_utils::workflow::related_wasm_instructions::<Unit>();
+        let task1 = Task::new(
+            RunInstruction::Expanded(instruction1),
+            config.clone().into(),
+            UcanPrf::default(),
+        );
+        let task2 = Task::new(
+            RunInstruction::Expanded(instruction2),
+            config.into(),
+            UcanPrf::default(),
+        );
+
+        let workflow = Workflow::new(vec![task1.clone(), task2.clone()]);
+        let ipld = Ipld::from(workflow.clone());
+        let ipld_to_workflow = ipld.try_into().unwrap();
+        assert_eq!(workflow, ipld_to_workflow);
+    }
+}

--- a/homestar-core/src/workflow/ability.rs
+++ b/homestar-core/src/workflow/ability.rs
@@ -3,6 +3,7 @@
 //! [Resource]: url::Url
 //! [UCAN Ability]: <https://github.com/ucan-wg/spec/#23-ability>
 
+use crate::{workflow, Unit};
 use libipld::{serde::from_ipld, Ipld};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt};
@@ -63,7 +64,7 @@ impl From<Ability> for Ipld {
 }
 
 impl TryFrom<Ipld> for Ability {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
         let ability = from_ipld::<String>(ipld)?;

--- a/homestar-core/src/workflow/config.rs
+++ b/homestar-core/src/workflow/config.rs
@@ -4,6 +4,7 @@
 //! [workflow]: super
 //! [Invocations]: super::Invocation
 
+use crate::{workflow, Unit};
 use libipld::{serde::from_ipld, Ipld};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, default::Default, time::Duration};
@@ -76,7 +77,7 @@ impl From<Resources> for Ipld {
 }
 
 impl<'a> TryFrom<&'a Ipld> for Resources {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: &Ipld) -> Result<Self, Self::Error> {
         Resources::try_from(ipld.to_owned())
@@ -84,7 +85,7 @@ impl<'a> TryFrom<&'a Ipld> for Resources {
 }
 
 impl TryFrom<Ipld> for Resources {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
         let map = from_ipld::<BTreeMap<String, Ipld>>(ipld)?;

--- a/homestar-core/src/workflow/error.rs
+++ b/homestar-core/src/workflow/error.rs
@@ -1,0 +1,163 @@
+//! Error types and implementations for [Workflow] interaction(s).
+//!
+//! [Workflow]: crate::Workflow
+
+use crate::{
+    workflow::{input::Args, Input},
+    Unit,
+};
+use libipld::Ipld;
+use serde::de::Error as DeError;
+
+/// Generic error type for [Workflow] use cases.
+///
+/// [Workflow]: crate::Workflow
+#[derive(thiserror::Error, Debug)]
+pub enum Error<T> {
+    /// Error encoding structure to a [Cid].
+    ///
+    /// [Cid]: libipld::cid::Cid
+    #[error("failed to encode CID: {0}")]
+    CidError(#[from] libipld::cid::Error),
+    /// Error thrown when condition or dynamic check is not met.
+    #[error("condition not met: {0}")]
+    ConditionNotMet(String),
+    /// Failure to decode/encode from/to DagCbor.
+    ///
+    /// The underlying error is a [anyhow::Error], per the
+    /// [DagCborCodec] implementation.
+    ///
+    /// [DagCborCodec]: libipld::cbor::DagCborCodec
+    #[error("failed to decode/encode DAG-CBOR: {0}")]
+    DagCborTranslationError(#[from] anyhow::Error),
+    /// Error converting from [Ipld] structure.
+    #[error("cannot convert from Ipld structure: {0}")]
+    FromIpldError(#[from] libipld::error::SerdeError),
+    /// Invalid match discriminant or enumeration.
+    #[error("invalid discriminant {0:#?}")]
+    InvalidDiscriminant(T),
+    /// Error related to a missing a field in a structure or key
+    /// in a map.
+    #[error("no {0} field set")]
+    MissingFieldError(String),
+    /// Error during parsing a [Url].
+    ///
+    /// Transparently forwards from [url::ParseError]'s `source` and
+    /// `Display` methods through to an underlying error.
+    ///
+    /// [Url]: url::Url
+    #[error(transparent)]
+    ParseResourceError(#[from] url::ParseError),
+    /// Generic unknown error.
+    #[error("unknown error")]
+    UnknownError,
+    /// Error when attempting to interpret a sequence of [u8]
+    /// as a string.
+    ///
+    /// Transparently forwards from [std::str::Utf8Error]'s `source` and
+    /// `Display` methods through to an underlying error.
+    #[error(transparent)]
+    Utf8Error(#[from] std::str::Utf8Error),
+}
+
+impl<T> Error<T> {
+    /// Return a [SerdeError] when returning an [Ipld] structure
+    /// that's not expected at the call-site.
+    ///
+    /// [SerdeError]: libipld::error::SerdeError
+    pub fn unexpected_ipld(ipld: Ipld) -> Self {
+        Error::FromIpldError(libipld::error::SerdeError::custom(format!(
+            "unexpected Ipld conversion: {ipld:#?}"
+        )))
+    }
+
+    /// Return an `invalid type` [SerdeError] when not matching an expected
+    /// [Ipld] list/sequence type.
+    ///
+    /// [SerdeError]: libipld::error::SerdeError
+    pub fn not_an_ipld_list() -> Self {
+        Error::FromIpldError(libipld::error::SerdeError::invalid_type(
+            serde::de::Unexpected::Seq,
+            &"an Ipld list / sequence",
+        ))
+    }
+}
+
+impl From<Error<Unit>> for Error<String> {
+    fn from(_err: Error<Unit>) -> Self {
+        Error::UnknownError
+    }
+}
+
+impl From<Error<String>> for Error<Unit> {
+    fn from(_err: Error<String>) -> Error<Unit> {
+        Error::UnknownError
+    }
+}
+
+impl<T> From<std::convert::Infallible> for Error<T> {
+    fn from(err: std::convert::Infallible) -> Self {
+        match err {}
+    }
+}
+
+/// Error type for parsing [Workflow] [Input]s.
+///
+/// [Workflow]: crate::Workflow
+#[derive(thiserror::Error, Debug)]
+pub enum InputParseError<T> {
+    /// Error converting from [Ipld] structure.
+    #[error("cannot convert from Ipld structure: {0}")]
+    FromIpldError(#[from] libipld::error::SerdeError),
+    /// Error converting from [Ipld] structure into [Args].
+    #[error("cannot convert from Ipld structure into arguments: {0:#?}")]
+    IpldToArgsError(Args<T>),
+    /// Unexpected [Input] in [Task] structure.
+    ///
+    /// [Task]: crate::workflow::Task
+    #[error("unexpected task input: {0:#?}")]
+    UnexpectedTaskInput(Input<T>),
+    /// Bubble-up conversion and other general [Workflow errors].
+    ///
+    /// [Workflow errors]: Error
+    #[error(transparent)]
+    WorkflowError(#[from] Error<T>),
+}
+
+impl<T> From<std::convert::Infallible> for InputParseError<T> {
+    fn from(err: std::convert::Infallible) -> Self {
+        match err {}
+    }
+}
+
+/// Error type for resolving promised [Cid]s within [Workflow] [Input]s.
+///
+/// [Cid]: libipld::Cid
+/// [Workflow]: crate::Workflow
+#[derive(thiserror::Error, Debug)]
+pub enum ResolveError {
+    /// Generic runtime error.
+    ///
+    /// Transparently forwards from [anyhow::Error]'s `source` and
+    /// `Display` methods through to an underlying error.
+    #[error(transparent)]
+    RuntimeError(#[from] anyhow::Error),
+    /// Transport error when attempting to resolve [Workflow] [Input]'s [Cid].
+    ///
+    /// [Cid]: libipld::Cid
+    /// [Workflow]: crate::Workflow
+    #[error("transport error during resolve phase of input Cid: {0}")]
+    TransportError(String),
+    /// Unable to resolve a [Cid] within a [Workflow]'s [Input].
+    ///
+    /// [Cid]: libipld::Cid
+    /// [Workflow]: crate::Workflow
+    #[error("error resolving input Cid: {0}")]
+    UnresolvedCidError(String),
+}
+
+impl From<std::convert::Infallible> for ResolveError {
+    fn from(err: std::convert::Infallible) -> Self {
+        match err {}
+    }
+}

--- a/homestar-core/src/workflow/input/parse.rs
+++ b/homestar-core/src/workflow/input/parse.rs
@@ -1,0 +1,89 @@
+use crate::workflow::{error::InputParseError, input::Args};
+
+/// Parsed [Args] consisting of [Inputs] for execution flows, as well as an
+/// optional function name/definition.
+///
+/// TODO: Extend via enumeration for singular objects/values.
+///
+/// [Inputs]: super::Input
+#[derive(Clone, Debug, PartialEq)]
+pub struct Parsed<T> {
+    args: Args<T>,
+    fun: Option<String>,
+}
+
+impl<T> Parsed<T> {
+    /// Initiate [Parsed] data structure with only [Args].
+    pub fn with(args: Args<T>) -> Self {
+        Parsed { args, fun: None }
+    }
+
+    /// Initiate [Parsed] data structure with a function name and
+    /// [Args].
+    pub fn with_fn(fun: String, args: Args<T>) -> Self {
+        Parsed {
+            args,
+            fun: Some(fun),
+        }
+    }
+
+    /// Parsed arguments.
+    pub fn args(&self) -> &Args<T> {
+        &self.args
+    }
+
+    /// Turn [Parsed] structure into owned [Args].
+    pub fn into_args(self) -> Args<T> {
+        self.args
+    }
+
+    /// Parsed function named.
+    pub fn fun(&self) -> Option<String> {
+        self.fun.as_ref().map(|f| f.to_string())
+    }
+}
+
+impl<T> From<Parsed<T>> for Args<T> {
+    fn from(apply: Parsed<T>) -> Self {
+        apply.args
+    }
+}
+
+/// Interface for [Instruction] implementations, relying on `homestore-core`
+/// to implement custom parsing specifics.
+///
+/// # Example
+///
+/// ```
+/// use homestar_core::{
+///     workflow::{
+///         input::{Args, Parse}, Ability, Input, Instruction,
+///     },
+///     Unit,
+/// };
+/// use libipld::Ipld;
+/// use url::Url;
+///
+/// let wasm = "bafkreidztuwoszw2dfnzufjpsjmzj67x574qcdm2autnhnv43o3t4zmh7i".to_string();
+/// let resource = Url::parse(format!("ipfs://{wasm}").as_str()).unwrap();
+///
+/// let inst = Instruction::unique(
+///     resource,
+///     Ability::from("wasm/run"),
+///     Input::<Unit>::Ipld(Ipld::List(vec![Ipld::Bool(true)]))
+/// );
+///
+/// let parsed = inst.input().parse().unwrap();
+///
+/// // turn into Args for invocation:
+/// let args: Args<Unit> = parsed.try_into().unwrap();
+/// ```
+///
+/// [Instruction]: crate::workflow::Instruction
+pub trait Parse<T> {
+    /// Function returning [Parsed] structure for execution/invocation.
+    ///
+    /// Note: meant to come before the `resolve` step
+    /// during runtime execution.
+    fn parse(&self) -> Result<Parsed<T>, InputParseError<T>>;
+}

--- a/homestar-core/src/workflow/issuer.rs
+++ b/homestar-core/src/workflow/issuer.rs
@@ -1,6 +1,7 @@
 //! Issuer referring to a principal (principal of least authority) that issues
 //! a receipt.
 
+use crate::{workflow, Unit};
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql},
@@ -46,7 +47,7 @@ impl From<Issuer> for Ipld {
 }
 
 impl TryFrom<Ipld> for Issuer {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
         let s = from_ipld::<String>(ipld)?;

--- a/homestar-core/src/workflow/nonce.rs
+++ b/homestar-core/src/workflow/nonce.rs
@@ -2,7 +2,7 @@
 //!
 //! [Instruction]: super::Instruction
 
-use anyhow::anyhow;
+use crate::{workflow, Unit};
 use enum_as_inner::EnumAsInner;
 use generic_array::{
     typenum::consts::{U12, U16},
@@ -61,7 +61,7 @@ impl From<Nonce> for Ipld {
 }
 
 impl TryFrom<Ipld> for Nonce {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
         if let Ipld::List(v) = ipld {
@@ -72,7 +72,9 @@ impl TryFrom<Ipld> for Nonce {
                 [Ipld::Integer(1), Ipld::Bytes(nonce)] => {
                     Ok(Nonce::Nonce128(*GenericArray::from_slice(nonce)))
                 }
-                _ => Err(anyhow!("unexpected conversion type")),
+                other_ipld => Err(workflow::Error::unexpected_ipld(
+                    other_ipld.to_owned().into(),
+                )),
             }
         } else {
             Ok(Nonce::Empty)
@@ -81,7 +83,7 @@ impl TryFrom<Ipld> for Nonce {
 }
 
 impl TryFrom<&Ipld> for Nonce {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: &Ipld) -> Result<Self, Self::Error> {
         TryFrom::try_from(ipld.to_owned())

--- a/homestar-core/src/workflow/pointer.rs
+++ b/homestar-core/src/workflow/pointer.rs
@@ -8,7 +8,7 @@
 //! [Instructions]: super::Instruction
 //! [Receipts]: super::Receipt
 
-use anyhow::ensure;
+use crate::{ensure, workflow, Unit};
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql},
@@ -122,11 +122,16 @@ impl From<&Await> for Ipld {
 }
 
 impl TryFrom<Ipld> for Await {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
         let map = from_ipld::<BTreeMap<String, Ipld>>(ipld)?;
-        ensure!(map.len() == 1, "unexpected keys inside awaited promise");
+        ensure!(
+            map.len() == 1,
+            workflow::Error::ConditionNotMet(
+                "await promise must jave only a single key ain a map".to_string()
+            )
+        );
 
         let (key, value) = map.into_iter().next().unwrap();
         let instruction = Pointer::try_from(value)?;
@@ -145,7 +150,7 @@ impl TryFrom<Ipld> for Await {
 }
 
 impl TryFrom<&Ipld> for Await {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: &Ipld) -> Result<Self, Self::Error> {
         TryFrom::try_from(ipld.to_owned())
@@ -198,7 +203,7 @@ impl From<Pointer> for Ipld {
 }
 
 impl TryFrom<Ipld> for Pointer {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
         let s: Cid = from_ipld(ipld)?;
@@ -207,7 +212,7 @@ impl TryFrom<Ipld> for Pointer {
 }
 
 impl TryFrom<&Ipld> for Pointer {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: &Ipld) -> Result<Self, Self::Error> {
         TryFrom::try_from(ipld.to_owned())

--- a/homestar-core/src/workflow/prf.rs
+++ b/homestar-core/src/workflow/prf.rs
@@ -3,6 +3,7 @@
 //!
 //! [Task]: super::Task
 
+use crate::{workflow, Unit};
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql},
@@ -46,7 +47,7 @@ impl From<UcanPrf> for Ipld {
 }
 
 impl TryFrom<Ipld> for UcanPrf {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
         if let Ipld::List(inner) = ipld {
@@ -63,7 +64,7 @@ impl TryFrom<Ipld> for UcanPrf {
 }
 
 impl TryFrom<&Ipld> for UcanPrf {
-    type Error = anyhow::Error;
+    type Error = workflow::Error<Unit>;
 
     fn try_from(ipld: &Ipld) -> Result<Self, Self::Error> {
         TryFrom::try_from(ipld.to_owned())

--- a/homestar-runtime/Cargo.toml
+++ b/homestar-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "homestar-runtime"
 version = "0.1.0"
-description = "Homestar runtime implementation"
+description = "Homestar CLI"
 keywords = ["ipfs", "workflows", "ipld", "ipvm"]
 categories = ["workflow-engines", "distributed-systems", "runtimes", "networking"]
 include = ["/src", "README.md", "LICENSE"]
@@ -33,14 +33,13 @@ anyhow = { workspace = true }
 async-trait = "0.1"
 axum = { version = "0.6", features = ["ws", "headers"] }
 byte-unit = { version = "4.0", default-features = false }
-clap = { version = "4.1", features = ["derive"] }
+clap = { version = "4.1", features = ["derive", "color", "help"] }
 concat-in-place = "1.1"
 config = "0.13"
 console-subscriber = { version = "0.1", default-features = false, features = [ "parking_lot" ], optional = true }
 crossbeam = "0.8"
 dagga = "0.2"
 diesel = { version = "2.1", features = ["sqlite", "r2d2", "returning_clauses_for_sqlite_3_35"] }
-diesel_migrations = "2.1"
 dotenvy = "0.15"
 enum-assoc = "0.4"
 futures = "0.3"
@@ -53,7 +52,6 @@ indexmap = "1.9"
 ipfs-api = { version = "0.17", optional = true }
 ipfs-api-backend-hyper = { version = "0.6", features = ["with-builder", "with-send-sync"], optional = true }
 itertools = "0.10"
-json = "0.12"
 libipld = "0.16"
 libp2p = { version = "0.51", features = ["kad", "request-response", "macros", "identify", "mdns", "gossipsub", "tokio", "dns", "mplex", "tcp", "noise", "yamux", "websocket"] }
 libp2p-identity = "0.1"
@@ -74,7 +72,9 @@ url = "2.3"
 
 [dev-dependencies]
 criterion = "0.4"
+diesel_migrations = "2.1"
 homestar-core = { version = "0.1", path = "../homestar-core", features = [ "test_utils" ] }
+json = "0.12"
 tokio-tungstenite = "0.18"
 
 [features]

--- a/homestar-runtime/src/cli.rs
+++ b/homestar-runtime/src/cli.rs
@@ -2,9 +2,17 @@
 
 use clap::Parser;
 
+const HELP_TEMPLATE: &str = "{about} {version}
+
+USAGE:
+    {usage}
+
+{all-args}
+";
+
 /// CLI arguments.
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None, help_template = HELP_TEMPLATE)]
 pub struct Args {
     /// Ipvm-specific [Argument].
     #[clap(subcommand)]
@@ -14,12 +22,15 @@ pub struct Args {
 /// CLI Argument types.
 #[derive(Debug, Parser)]
 pub enum Argument {
-    /// TODO: Run [Workflow] given a file.
-    ///
-    /// [Workflow]: crate::Workflow
+    /// Run a workflow given a file.
     Run {
         /// Configuration file for *homestar* node settings.
-        #[arg(short, long)]
+        #[arg(
+            short = 'c',
+            long = "config",
+            value_name = "CONFIG",
+            help = "runtime configuration file"
+        )]
         runtime_config: Option<String>,
     },
 }

--- a/homestar-runtime/src/lib.rs
+++ b/homestar-runtime/src/lib.rs
@@ -36,7 +36,6 @@ pub use receipt::Receipt;
 pub use runtime::*;
 pub use settings::Settings;
 pub use worker::Worker;
-pub use workflow::Workflow;
 
 /// Test utilities.
 #[cfg(any(test, feature = "test_utils"))]

--- a/homestar-runtime/src/main.rs
+++ b/homestar-runtime/src/main.rs
@@ -15,6 +15,7 @@ use homestar_runtime::{
 };
 use std::sync::Arc;
 
+/// TODO: All
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     logger::init()?;

--- a/homestar-runtime/src/scheduler.rs
+++ b/homestar-runtime/src/scheduler.rs
@@ -5,13 +5,16 @@
 
 use crate::{
     db::{Connection, Database},
-    workflow::{Resource, Vertex},
-    Db, Workflow,
+    workflow::{Builder, Resource, Vertex},
+    Db,
 };
 use anyhow::Result;
 use dagga::Node;
 use futures::future::BoxFuture;
-use homestar_core::workflow::{InstructionResult, LinkMap, Pointer};
+use homestar_core::{
+    workflow::{InstructionResult, LinkMap, Pointer},
+    Workflow,
+};
 use homestar_wasm::io::Arg;
 use indexmap::IndexMap;
 use libipld::Cid;
@@ -78,7 +81,8 @@ impl<'a> TaskScheduler<'a> {
     where
         F: FnOnce(Vec<Resource>) -> BoxFuture<'a, Result<IndexMap<Resource, Vec<u8>>>>,
     {
-        let graph = workflow.graph()?;
+        let builder = Builder::new(workflow);
+        let graph = builder.graph()?;
         let mut schedule = graph.schedule;
         let schedule_length = schedule.len();
         let fetched = fetch_fn(graph.resources).await?;

--- a/homestar-runtime/src/tasks/wasm.rs
+++ b/homestar-runtime/src/tasks/wasm.rs
@@ -1,10 +1,9 @@
 use super::FileLoad;
-use anyhow::Result;
 use async_trait::async_trait;
 use homestar_core::workflow::input::Args;
 use homestar_wasm::{
     io::{Arg, Output},
-    wasmtime::{world::Env, State, World},
+    wasmtime::{world::Env, Error as WasmRuntimeError, State, World},
 };
 
 #[allow(missing_debug_implementations)]
@@ -13,7 +12,7 @@ pub(crate) struct WasmContext {
 }
 
 impl WasmContext {
-    pub(crate) fn new(data: State) -> Result<Self> {
+    pub(crate) fn new(data: State) -> Result<Self, WasmRuntimeError> {
         Ok(Self {
             env: World::default(data)?,
         })
@@ -25,7 +24,7 @@ impl WasmContext {
         bytes: Vec<u8>,
         fun_name: &'a str,
         args: Args<Arg>,
-    ) -> Result<Output> {
+    ) -> Result<Output, WasmRuntimeError> {
         let env = World::instantiate_with_current_env(bytes, fun_name, &mut self.env).await?;
         env.execute(args).await
     }

--- a/homestar-runtime/src/workflow/info.rs
+++ b/homestar-runtime/src/workflow/info.rs
@@ -12,7 +12,7 @@ const NUM_TASKS_KEY: &str = "num_tasks";
 
 /// [Workflow] information stored in the database.
 ///
-/// [Workflow]: crate::Workflow
+/// [Workflow]: homestar_core::Workflow
 #[derive(Debug, Clone, PartialEq, Queryable, Insertable, Identifiable, Selectable, Hash)]
 #[diesel(table_name = crate::db::schema::workflows, primary_key(cid))]
 pub struct Stored {
@@ -28,7 +28,7 @@ impl Stored {
 
 /// [Workflow] information stored in the database, tied to [receipts].
 ///
-/// [Workflow]: crate::Workflow
+/// [Workflow]: homestar_core::Workflow
 /// [receipts]: crate::Receipt
 #[derive(Debug, Clone, PartialEq, Queryable, Insertable, Identifiable, Associations, Hash)]
 #[diesel(belongs_to(Receipt, foreign_key = receipt_cid))]
@@ -52,7 +52,7 @@ impl StoredReceipt {
 /// to relate to it as a key-value relationship of (workflow)
 /// cid => [Info].
 ///
-/// [Workflow]: crate::Workflow
+/// [Workflow]: homestar_core::Workflow
 #[derive(Debug, Clone, PartialEq)]
 pub struct Info {
     pub(crate) cid: Cid,
@@ -84,11 +84,25 @@ impl Info {
         }
     }
 
+    /// Get unique identifier, [Cid], of [Workflow].
+    ///
+    /// [Workflow]: homestar_core::Workflow
+    pub fn cid(&self) -> Cid {
+        self.cid
+    }
+
     /// Get the [Cid] of a [Workflow] as a [String].
     ///
-    /// [Workflow]: crate::Workflow
-    pub fn cid(&self) -> String {
+    /// [Workflow]: homestar_core::Workflow
+    pub fn cid_as_string(&self) -> String {
         self.cid.to_string()
+    }
+
+    /// Get the [Cid] of a [Workflow] as bytes.
+    ///
+    /// [Workflow]: homestar_core::Workflow
+    pub fn cid_as_bytes(&self) -> Vec<u8> {
+        self.cid().to_bytes()
     }
 
     /// Set the progress / step of the [Info].
@@ -174,10 +188,10 @@ impl TryFrom<Vec<u8>> for Info {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Workflow;
     use homestar_core::{
         test_utils,
         workflow::{config::Resources, instruction::RunInstruction, prf::UcanPrf, Task},
+        Workflow,
     };
     use homestar_wasm::io::Arg;
 

--- a/homestar-runtime/src/workflow/settings.rs
+++ b/homestar-runtime/src/workflow/settings.rs
@@ -1,4 +1,6 @@
-//! Workflow settings for a worker's run/execution.
+//! [Workflow] settings for a worker's run/execution.
+//!
+//! [Workflow]: crate::Workflow
 
 /// Workflow settings.
 #[derive(Debug, Clone, PartialEq)]

--- a/homestar-wasm/Cargo.toml
+++ b/homestar-wasm/Cargo.toml
@@ -30,9 +30,8 @@ itertools = "0.10"
 libipld = "0.16"
 libipld-core = { version = "0.16", features = ["serde-codec", "serde"] }
 rust_decimal = "1.28"
-serde_ipld_dagcbor = "0.2"
 stacker = "0.1"
-thiserror = "1.0"
+thiserror = { workspace = true }
 tracing = { workspace = true }
 wasi-common = "8.0"
 wasmparser = "0.104"
@@ -44,6 +43,7 @@ wit-component = "0.8"
 [dev-dependencies]
 criterion = "0.4"
 image = "0.24"
+serde_ipld_dagcbor = "0.2"
 tokio = { workspace = true }
 
 [features]

--- a/homestar-wasm/src/error.rs
+++ b/homestar-wasm/src/error.rs
@@ -1,0 +1,107 @@
+//! Error types and implementations for `Ipld <=> Wasm` interaction(s).
+
+/// Error types related for [Ipld] to/from [Wasm value] interpretation.
+///
+/// [Ipld]: libipld::Ipld
+/// [Wasm value]: wasmtime::component:Val
+#[derive(thiserror::Error, Debug)]
+#[allow(clippy::enum_variant_names)]
+pub enum InterpreterError {
+    /// Error encoding structure to a [Cid].
+    ///
+    /// [Cid]: libipld::cid::Cid
+    #[error("failed to encode CID: {0}")]
+    CidError(#[from] libipld::cid::Error),
+    /// Error converting from [Decimal] precision to [f64].
+    ///
+    /// [Decimal]: rust_decimal::Decimal
+    /// [f64]: f64
+    #[error("Failed to convert from decimal to f64 float {0}")]
+    DecimalToFloatError(rust_decimal::Decimal),
+    /// Error converting from from [f32] to [Decimal].
+    ///
+    /// [Decimal]: rust_decimal::Decimal
+    #[error("Failed to convert from f32 float {0} to decimal")]
+    FloatToDecimalError(f32),
+    /// Error converting from [Ipld] structure.
+    ///
+    /// [Ipld]: libipld::Ipld
+    #[error("cannot convert from Ipld structure: {0}")]
+    FromIpldError(#[from] libipld::error::SerdeError),
+    /// Error casting from [Ipld] [i128] structure to a lower precision integer.
+    ///
+    /// [Ipld]: libipld::Ipld
+    #[error("failed to cast Ipld i128 to integer type: {0}")]
+    IpldToIntError(#[from] std::num::TryFromIntError),
+    /// Error converting from [Ipld] structure to [Wit] structure.
+    ///
+    /// [Ipld]: libipld::Ipld
+    /// [Wit]: wasmtime::component::Val
+    #[error("no compatible Ipld type for Wit structure: {0:#?}")]
+    IpldToWitError(String),
+    /// Error involving mismatches with [Ipld] maps.
+    ///
+    /// [Ipld]: libipld::Ipld
+    #[error("{0}")]
+    MapTypeError(String),
+    /// Failure to match or find [Wit union] discriminant.
+    ///
+    /// [Wit union]: wasmtime::component::Union
+    #[error("no match within <union>: {0}")]
+    NoDiscriminantMatched(String),
+    /// Bubble-up [TagsError] errors while executing the interpreter.
+    #[error(transparent)]
+    TagsError(#[from] TagsError),
+    /// Type mismatch error between expected and given types.
+    #[error("component type mismatch: expected: {expected}, found: {given:#?}")]
+    TypeMismatchError {
+        /// Expected type.
+        expected: String,
+        /// Given type or lack thereof.
+        given: Option<String>,
+    },
+    /// Failed to parse, handle, or otherwise convert to/from/between
+    /// Wit/Wasm types.
+    ///
+    /// The underlying error is a [anyhow::Error], per the
+    /// [wasmtime::component::types::Type] implementation.
+    #[error(transparent)]
+    WitTypeError(#[from] anyhow::Error),
+    /// Error converting from [Wit] structure to [Ipld] structure.
+    ///
+    /// [Ipld]: libipld::Ipld
+    /// [Wit]: wasmtime::component::Val
+    #[error("no compatible WIT type for Ipld structure: {0:#?}")]
+    WitToIpldError(libipld::Ipld),
+}
+
+/// Error type for handling [Tags] stack structure.
+///
+/// [Tags]: crate::wasmtime::ipld::Tags
+#[allow(clippy::enum_variant_names)]
+#[derive(thiserror::Error, Debug)]
+pub enum TagsError {
+    /// An error returned by [atomic_refcell::AtomicRefCell::try_borrow].
+    #[error("{0}")]
+    BorrowError(atomic_refcell::BorrowError),
+    /// An error returned by [atomic_refcell::AtomicRefCell::try_borrow_mut].
+    #[error("{0}")]
+    BorrowMutError(atomic_refcell::BorrowMutError),
+    /// Working with [Tags] stack structure should never be empty.
+    ///
+    /// [Tags]: crate::wasmtime::ipld::Tags
+    #[error("structure must contain at least one element")]
+    TagsEmptyError,
+}
+
+impl From<atomic_refcell::BorrowError> for TagsError {
+    fn from(e: atomic_refcell::BorrowError) -> Self {
+        TagsError::BorrowError(e)
+    }
+}
+
+impl From<atomic_refcell::BorrowMutError> for TagsError {
+    fn from(e: atomic_refcell::BorrowMutError) -> Self {
+        TagsError::BorrowMutError(e)
+    }
+}

--- a/homestar-wasm/src/lib.rs
+++ b/homestar-wasm/src/lib.rs
@@ -14,6 +14,7 @@
 //! [homestar-runtime]: <https://docs.rs/homestar-runtime>
 //! [Wasmtime]: <https://wasmtime.dev/>
 
+pub mod error;
 pub mod io;
 pub mod test_utils;
 pub mod wasmtime;

--- a/homestar-wasm/src/wasmtime/error.rs
+++ b/homestar-wasm/src/wasmtime/error.rs
@@ -1,0 +1,50 @@
+//! Error types and implementations for Wasm (via [Wasmtime]) execution,
+//! instantiation, and runtime interaction(s).
+//!
+//! [Wasmtime]: <https://docs.rs/wasmtime/latest/wasmtime>
+
+/// Generic error type for Wasm execution, conversions, instantiations, etc.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Failure to convert from Wasm binary into Wasm component.
+    #[error("cannot convert from binary structure to Wasm component")]
+    IntoWasmComponentError(#[source] anyhow::Error),
+    /// Bubble-up [ResolveError]s for [Cid]s still awaiting resolution.
+    ///
+    /// [ResolveError]: homestar_core::workflow::error::ResolveError
+    /// [Cid]: libipld::Cid
+    #[error(transparent)]
+    PromiseError(#[from] homestar_core::workflow::error::ResolveError),
+    /// Generic unknown error.
+    #[error("unknown error")]
+    UnknownError,
+    /// Failure to instantiate Wasm component and its host bindings.
+    #[error("bindings not yet instantiated for wasm environment")]
+    WasmInstantiationError,
+    /// Failure to parse Wasm binary.
+    ///
+    /// Transparently forwards from [wasmparser::BinaryReaderError]'s `source`
+    /// and `Display` methods through to an underlying error.
+    #[error(transparent)]
+    WasmParserError(#[from] wasmparser::BinaryReaderError),
+    /// Generic [wasmtime] runtime error.
+    ///
+    /// Transparently forwards from [anyhow::Error]'s `source` and
+    /// `Display` methods through to an underlying error.
+    #[error(transparent)]
+    WasmRuntimeError(#[from] anyhow::Error),
+    /// Failure to find Wasm function for execution.
+    #[error("Wasm function {0} not found")]
+    WasmFunctionNotFoundError(String),
+    /// [Wat] as Wasm component error.
+    ///
+    /// [Wat]: wat
+    #[error("{0}")]
+    WatComponentError(String),
+    /// [wat]-related error.
+    ///
+    /// Transparently forwards from [wat::Error]'s `source`
+    /// and `Display` methods through to an underlying error.
+    #[error(transparent)]
+    WatError(#[from] wat::Error),
+}

--- a/homestar-wasm/src/wasmtime/mod.rs
+++ b/homestar-wasm/src/wasmtime/mod.rs
@@ -5,7 +5,9 @@
 //! [Ipld]: libipld::Ipld
 
 pub mod config;
+mod error;
 pub mod ipld;
 pub mod world;
 
+pub use error::*;
 pub use world::{State, World};

--- a/homestar-wasm/src/wasmtime/world.rs
+++ b/homestar-wasm/src/wasmtime/world.rs
@@ -95,13 +95,13 @@ impl<T> Env<T> {
         let param_types = self
             .bindings
             .as_mut()
-            .ok_or_else(|| Error::WasmInstantiationError)?
+            .ok_or(Error::WasmInstantiationError)?
             .func()
             .params(&self.store);
         let result_types = self
             .bindings
             .as_mut()
-            .ok_or_else(|| Error::WasmInstantiationError)?
+            .ok_or(Error::WasmInstantiationError)?
             .func()
             .results(&self.store);
 
@@ -140,14 +140,14 @@ impl<T> Env<T> {
 
         self.bindings
             .as_mut()
-            .ok_or_else(|| Error::WasmInstantiationError)?
+            .ok_or(Error::WasmInstantiationError)?
             .func()
             .call_async(&mut self.store, &params, &mut results_alloc)
             .await?;
 
         self.bindings
             .as_mut()
-            .ok_or_else(|| Error::WasmInstantiationError)?
+            .ok_or(Error::WasmInstantiationError)?
             .func()
             .post_return_async(&mut self.store)
             .await?;

--- a/homestar-wasm/src/wasmtime/world.rs
+++ b/homestar-wasm/src/wasmtime/world.rs
@@ -3,11 +3,18 @@
 //!
 //! [Wasmtime]: <https://docs.rs/wasmtime/latest/wasmtime/>
 
-use super::ipld::{InterfaceType, RuntimeVal};
-use crate::io::{Arg, Output};
-use anyhow::{anyhow, bail, Result};
+use crate::{
+    io::{Arg, Output},
+    wasmtime::{
+        ipld::{InterfaceType, RuntimeVal},
+        Error,
+    },
+};
 use heck::{ToKebabCase, ToSnakeCase};
-use homestar_core::workflow::{input::Args, Input};
+use homestar_core::{
+    bail,
+    workflow::{error::ResolveError, input::Args, Input},
+};
 use std::iter;
 use wasmtime::{
     component::{self, Component, Func, Instance, Linker},
@@ -81,20 +88,20 @@ impl<T> Env<T> {
     ///
     /// [Wit]: <https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md>
     /// [Ipld]: libipld::Ipld
-    pub async fn execute(&mut self, args: Args<Arg>) -> Result<Output>
+    pub async fn execute(&mut self, args: Args<Arg>) -> Result<Output, Error>
     where
         T: Send,
     {
         let param_types = self
             .bindings
             .as_mut()
-            .ok_or_else(|| anyhow!("bindings not yet instantiated for wasm environment"))?
+            .ok_or_else(|| Error::WasmInstantiationError)?
             .func()
             .params(&self.store);
         let result_types = self
             .bindings
             .as_mut()
-            .ok_or_else(|| anyhow!("bindings not yet instantiated for wasm environment"))?
+            .ok_or_else(|| Error::WasmInstantiationError)?
             .func()
             .results(&self.store);
 
@@ -103,22 +110,27 @@ impl<T> Env<T> {
             args.into_inner().into_iter(),
         )
         .try_fold(vec![], |mut acc, (typ, arg)| {
+            // Remove unwraps
             let v = match arg {
-                Input::Ipld(ipld) => RuntimeVal::try_from(ipld, &InterfaceType::from(typ))?.value(),
+                Input::Ipld(ipld) => RuntimeVal::try_from(ipld, &InterfaceType::from(typ))
+                    .unwrap()
+                    .value(),
                 Input::Arg(val) => match val.into_inner() {
-                    Arg::Ipld(ipld) => {
-                        RuntimeVal::try_from(ipld, &InterfaceType::from(typ))?.value()
-                    }
+                    Arg::Ipld(ipld) => RuntimeVal::try_from(ipld, &InterfaceType::from(typ))
+                        .unwrap()
+                        .value(),
                     Arg::Value(v) => v,
                 },
-                Input::Deferred(await_promise) => bail!(anyhow!(
-                    "deferred task not yet resolved for {}: {}",
-                    await_promise.result(),
-                    await_promise.instruction_cid()
+                Input::Deferred(await_promise) => bail!(Error::PromiseError(
+                    ResolveError::UnresolvedCidError(format!(
+                        "deferred task not yet resolved for {}: {}",
+                        await_promise.result(),
+                        await_promise.instruction_cid()
+                    ))
                 )),
             };
             acc.push(v);
-            Ok::<_, anyhow::Error>(acc)
+            Ok::<_, Error>(acc)
         })?;
 
         let mut results_alloc: Vec<component::Val> = result_types
@@ -128,14 +140,14 @@ impl<T> Env<T> {
 
         self.bindings
             .as_mut()
-            .ok_or_else(|| anyhow!("bindings not yet instantiated for wasm environment"))?
+            .ok_or_else(|| Error::WasmInstantiationError)?
             .func()
             .call_async(&mut self.store, &params, &mut results_alloc)
             .await?;
 
         self.bindings
             .as_mut()
-            .ok_or_else(|| anyhow!("bindings not yet instantiated for wasm environment"))?
+            .ok_or_else(|| Error::WasmInstantiationError)?
             .func()
             .post_return_async(&mut self.store)
             .await?;
@@ -181,7 +193,7 @@ impl World {
     /// for a [World], given [State].
     ///
     /// [environment]: Env
-    pub fn default(data: State) -> Result<Env<State>> {
+    pub fn default(data: State) -> Result<Env<State>, Error> {
         let config = Self::configure();
         let engine = Engine::new(&config)?;
         let linker = Self::define_linker(&engine);
@@ -203,7 +215,11 @@ impl World {
     /// for future invocations to use the already-initialized linker, store.
     ///
     /// Used when first initiating a module of a workflow.
-    pub async fn instantiate(bytes: Vec<u8>, fun_name: &str, data: State) -> Result<Env<State>> {
+    pub async fn instantiate(
+        bytes: Vec<u8>,
+        fun_name: &str,
+        data: State,
+    ) -> Result<Env<State>, Error> {
         let config = Self::configure();
         let engine = Engine::new(&config)?;
         let linker = Self::define_linker(&engine);
@@ -236,7 +252,7 @@ impl World {
         bytes: Vec<u8>,
         fun_name: &'a str,
         env: &'a mut Env<T>,
-    ) -> Result<&'a mut Env<T>>
+    ) -> Result<&'a mut Env<T>, Error>
     where
         T: Send,
     {
@@ -291,7 +307,7 @@ impl World {
         mut store: impl wasmtime::AsContextMut,
         instance: &Instance,
         fun_name: &str,
-    ) -> Result<Self> {
+    ) -> Result<Self, Error> {
         let mut store_ctx = store.as_context_mut();
         let mut exports = instance.exports(&mut store_ctx);
         let mut __exports = exports.root();
@@ -299,14 +315,14 @@ impl World {
             .func(fun_name)
             .or_else(|| __exports.func(&fun_name.to_kebab_case()))
             .or_else(|| __exports.func(&fun_name.to_snake_case()))
-            .ok_or_else(|| anyhow!("function not found"))?;
+            .ok_or_else(|| Error::WasmFunctionNotFoundError(fun_name.to_string()))?;
 
         Ok(World(func))
     }
 }
 
 /// Turn bytes into a Wasm [Component] module.
-fn component_from_bytes(bytes: &[u8], engine: Engine) -> Result<Component> {
+fn component_from_bytes(bytes: &[u8], engine: Engine) -> Result<Component, Error> {
     fn is_component(chunk: wasmparser::Chunk<'_>) -> bool {
         matches!(
             chunk,
@@ -322,21 +338,23 @@ fn component_from_bytes(bytes: &[u8], engine: Engine) -> Result<Component> {
     match wasmparser::Parser::new(0).parse(bytes, true) {
         Ok(chunk) => {
             if is_component(chunk) {
-                Component::from_binary(&engine, bytes)
+                Component::from_binary(&engine, bytes).map_err(Error::IntoWasmComponentError)
             } else {
                 let component = ComponentEncoder::default()
                     .module(bytes)?
                     .validate(true)
                     .encode()?;
-                Component::from_binary(&engine, &component)
+                Component::from_binary(&engine, &component).map_err(Error::IntoWasmComponentError)
             }
         }
         Err(_) => {
             let wasm_bytes = wat::parse_bytes(bytes)?;
             if is_component(wasmparser::Parser::new(0).parse(&wasm_bytes, true)?) {
-                Component::from_binary(&engine, &wasm_bytes)
+                Component::from_binary(&engine, &wasm_bytes).map_err(Error::IntoWasmComponentError)
             } else {
-                Err(anyhow!("WAT must reference a Wasm component."))
+                Err(Error::WatComponentError(
+                    "WAT must reference a Wasm component.".to_string(),
+                ))
             }
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"


### PR DESCRIPTION
Closes https://github.com/ipvm-wg/homestar/issues/62

This PR includes:

* flake commands for helpful shortcuts
* move to cargo nextest
* worker tests
* addition of workspace macros bail and ensure for internal error handling
* moves general workflow structure to homestar-core, with generic handling, and allows for further building blocks