### PR TITLE
refactor: add memory limits, update scheduler, progress and info

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,5 @@
 use_flake
 
-export RUST_LOG=homestar_runtime=debug,atuin_client=warn,libp2p=info
+export RUST_LOG=homestar_runtime=debug,atuin_client=warn,libp2p=info,libp2p_gossipsub::behaviour=debug
 export RUST_BACKTRACE=full
+export RUSTFLAGS="--cfg tokio_unstable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,6 +2384,7 @@ name = "homestar-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "byte-unit",
  "criterion",
  "diesel",
  "enum-as-inner 0.6.0",
@@ -2451,10 +2452,12 @@ dependencies = [
  "reqwest",
  "semver",
  "serde",
+ "serde_ipld_dagcbor",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.19.0",
  "tracing",
+ "tracing-appender",
  "tracing-logfmt",
  "tracing-subscriber",
  "tryhard",
@@ -2466,6 +2469,7 @@ name = "homestar-wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "atomic_refcell",
  "criterion",
  "enum-as-inner 0.6.0",
@@ -2474,7 +2478,6 @@ dependencies = [
  "image",
  "itertools",
  "libipld",
- "libipld-core",
  "rust_decimal",
  "serde_ipld_dagcbor",
  "stacker",
@@ -6168,6 +6171,17 @@ dependencies = [
  "pin-project-lite 0.2.9",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,14 @@ rust-version = "1.66.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
+async-trait = "0.1"
+byte-unit = { version = "4.0", default-features = false }
 enum-assoc = " 1.1"
 enum-as-inner = "0.6"
+libipld = { version = "0.16", features = ["serde-codec"] }
+serde_ipld_dagcbor = "0.3"
 thiserror = "1.0"
-tokio = { version = "1.26", features = ["fs", "io-util", "io-std", "macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.26", features = ["fs", "io-util", "io-std", "macros", "rt", "rt-multi-thread", "tracing"] }
 tracing = "0.1"
 
 # Speedup build on macOS

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
           cargo clippy
           cargo build --release
           nx-test
+          nx-test-0
         '';
 
         db = pkgs.writeScriptBin "db" ''

--- a/homestar-core/Cargo.toml
+++ b/homestar-core/Cargo.toml
@@ -22,12 +22,13 @@ doctest = true
 # return to version.workspace = true after the following issue is fixed:
 # https://github.com/DevinR528/cargo-sort/issues/47
 anyhow = { workspace = true }
+byte-unit = { workspace = true }
 diesel = { version = "2.0", features = ["sqlite"] }
 enum-as-inner = { workspace = true }
 enum-assoc = { workspace = true }
 generic-array = { version = "0.14", features = ["serde"] }
 indexmap = "1.9"
-libipld = { version = "0.16", features = ["serde-codec"] }
+libipld = { workspace = true }
 libsqlite3-sys = { version = "0.26", features = ["bundled"] }
 proptest = { version = "1.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/homestar-core/src/consts.rs
+++ b/homestar-core/src/consts.rs
@@ -4,3 +4,5 @@
 pub const INVOCATION_VERSION: &str = "0.2.0";
 /// DagCbor codec.
 pub const DAG_CBOR: u64 = 0x71;
+/// 4GiB maximum memory for Wasm.
+pub const WASM_MAX_MEMORY: u64 = byte_unit::n_gib_bytes!(4);

--- a/homestar-core/src/workflow/receipt.rs
+++ b/homestar-core/src/workflow/receipt.rs
@@ -8,6 +8,8 @@ use crate::{
 use libipld::{self, cbor::DagCborCodec, prelude::Codec, serde::from_ipld, Ipld};
 use std::collections::BTreeMap;
 
+pub mod metadata;
+
 const RAN_KEY: &str = "ran";
 const OUT_KEY: &str = "out";
 const ISSUER_KEY: &str = "iss";

--- a/homestar-core/src/workflow/receipt/metadata.rs
+++ b/homestar-core/src/workflow/receipt/metadata.rs
@@ -1,0 +1,9 @@
+//! Metadata related to [Receipt]s.
+
+/// Metadata key for an operation or function name.
+pub const OP_KEY: &str = "op";
+
+/// Metadata key for a workflow [Cid].
+///
+/// [Cid]: libipld::Cid
+pub const WORKFLOW_KEY: &str = "workflow";

--- a/homestar-core/src/workflow/task.rs
+++ b/homestar-core/src/workflow/task.rs
@@ -172,7 +172,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{test_utils, workflow::config::Resources, Unit};
+    use crate::{consts::WASM_MAX_MEMORY, test_utils, workflow::config::Resources, Unit};
 
     #[test]
     fn ipld_roundtrip() {
@@ -207,6 +207,7 @@ mod test {
                     METADATA_KEY.into(),
                     Ipld::Map(BTreeMap::from([
                         ("fuel".into(), Ipld::Integer(u64::MAX.into())),
+                        ("memory".into(), Ipld::Integer(WASM_MAX_MEMORY.into())),
                         ("time".into(), Ipld::Integer(100_000))
                     ]))
                 ),
@@ -236,6 +237,7 @@ mod test {
                     METADATA_KEY.into(),
                     Ipld::Map(BTreeMap::from([
                         ("fuel".into(), Ipld::Integer(u64::MAX.into())),
+                        ("memory".into(), Ipld::Integer(WASM_MAX_MEMORY.into())),
                         ("time".into(), Ipld::Integer(100_000))
                     ]))
                 ),

--- a/homestar-runtime/Cargo.toml
+++ b/homestar-runtime/Cargo.toml
@@ -32,7 +32,7 @@ ansi_term = { version = "0.12", optional = true, default-features = false }
 anyhow = { workspace = true }
 async-trait = "0.1"
 axum = { version = "0.6", features = ["ws", "headers"] }
-byte-unit = { version = "4.0", default-features = false }
+byte-unit = { workspace = true }
 clap = { version = "4.3", features = ["derive", "color", "help"] }
 concat-in-place = "1.1"
 config = "0.13"
@@ -52,18 +52,20 @@ indexmap = "1.9"
 ipfs-api = { version = "0.17", optional = true }
 ipfs-api-backend-hyper = { version = "0.6", features = ["with-builder", "with-send-sync"], optional = true }
 itertools = "0.10"
-libipld = "0.16"
-libp2p = { version = "0.51", features = ["kad", "request-response", "macros", "identify", "mdns", "gossipsub", "tokio", "dns", "mplex", "tcp", "noise", "yamux", "websocket"] }
+libipld = { workspace = true }
+libp2p = { version = "0.51", default-features = false, features = ["kad", "request-response", "macros", "identify", "mdns", "gossipsub", "tokio", "dns", "mplex", "tcp", "noise", "yamux", "websocket"] }
 libsqlite3-sys = { version = "0.26", features = ["bundled"] }
 openssl = { version = "0.10", features = ["vendored"] }
 proptest = { version = "1.2", optional = true }
 reqwest = { version = "0.11", features = ["json"] }
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_ipld_dagcbor = { workspace = true }
 thiserror = "1.0"
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-logfmt = { version = "0.3", optional = true }
+tracing-appender = "0.2"
+tracing-logfmt = "0.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "parking_lot", "registry"] }
 tryhard = "0.5"
 url = "2.4"
@@ -76,11 +78,10 @@ json = "0.12"
 tokio-tungstenite = "0.19"
 
 [features]
-default = ["console", "ipfs", "logfmt"]
+default = ["ipfs"]
 ansi-logs = ["ansi_term"]
 console = ["console-subscriber"]
 ipfs = ["ipfs-api", "ipfs-api-backend-hyper"]
-logfmt = ["tracing-logfmt"]
 test_utils = ["proptest"]
 
 [package.metadata.docs.rs]

--- a/homestar-runtime/src/db.rs
+++ b/homestar-runtime/src/db.rs
@@ -104,7 +104,7 @@ pub trait Database {
     /// work across vecs/arrays.
     ///
     /// [Instruction]: homestar_core::workflow::Instruction
-    fn find_instructions(pointers: Vec<Pointer>, conn: &mut Connection) -> Result<Vec<Receipt>> {
+    fn find_instructions(pointers: &Vec<Pointer>, conn: &mut Connection) -> Result<Vec<Receipt>> {
         let found_receipts = schema::receipts::dsl::receipts
             .filter(schema::receipts::instruction.eq_any(pointers))
             .load(conn)?;

--- a/homestar-runtime/src/lib.rs
+++ b/homestar-runtime/src/lib.rs
@@ -32,7 +32,7 @@ pub mod workflow;
 pub use db::Db;
 #[cfg(feature = "ipfs")]
 pub use network::ipfs::IpfsCli;
-pub use receipt::Receipt;
+pub use receipt::{Receipt, RECEIPT_TAG, VERSION_KEY};
 pub use runtime::*;
 pub use settings::Settings;
 pub use worker::Worker;

--- a/homestar-runtime/src/logger.rs
+++ b/homestar-runtime/src/logger.rs
@@ -1,50 +1,54 @@
 //! Logger initialization.
 
 use anyhow::Result;
-#[cfg(not(feature = "logfmt"))]
-use tracing_subscriber::prelude::*;
-#[cfg(feature = "logfmt")]
 use tracing_subscriber::{layer::SubscriberExt as _, prelude::*, EnvFilter};
+
+const DIRECTIVE_EXPECT: &str = "Invalid tracing directive";
 
 /// Initialize a [tracing_subscriber::Registry] with a [logfmt] layer.
 ///
 /// [logfmt]: <https://brandur.org/logfmt>
-#[cfg(feature = "logfmt")]
-pub fn init() -> Result<()> {
-    let registry = tracing_subscriber::Registry::default()
-        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
-        .with(tracing_logfmt::layer());
+pub fn init(writer: tracing_appender::non_blocking::NonBlocking) -> Result<()> {
+    let format_layer = tracing_subscriber::fmt::layer()
+        .event_format(tracing_logfmt::EventsFormatter::default())
+        .fmt_fields(tracing_logfmt::FieldsFormatter::default())
+        .with_writer(writer);
 
     #[cfg(all(feature = "console", tokio_unstable))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "console")))]
-    {
-        let console_layer = console_subscriber::ConsoleLayer::builder()
-            .retention(Duration::from_secs(60))
-            .spawn();
-
-        registry.with(console_layer).init();
-    }
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| {
+            EnvFilter::new("info")
+                .add_directive("atuin_client=warn".parse().expect(DIRECTIVE_EXPECT))
+                .add_directive("libp2p=info".parse().expect(DIRECTIVE_EXPECT))
+                .add_directive(
+                    "libp2p_gossipsub::behaviour=debug"
+                        .parse()
+                        .expect(DIRECTIVE_EXPECT),
+                )
+        })
+        .add_directive("tokio=trace".parse().expect(DIRECTIVE_EXPECT))
+        .add_directive("runtime=trace".parse().expect(DIRECTIVE_EXPECT));
 
     #[cfg(any(not(feature = "console"), not(tokio_unstable)))]
-    {
-        registry.init();
-    }
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new("info")
+            .add_directive("atuin_client=warn".parse().expect(DIRECTIVE_EXPECT))
+            .add_directive("libp2p=info".parse().expect(DIRECTIVE_EXPECT))
+            .add_directive(
+                "libp2p_gossipsub::behaviour=debug"
+                    .parse()
+                    .expect(DIRECTIVE_EXPECT),
+            )
+    });
 
-    Ok(())
-}
-
-/// Initialize a default [tracing_subscriber::FmtSubscriber].
-#[cfg(not(feature = "logfmt"))]
-pub fn init() -> Result<()> {
-    let registry = tracing_subscriber::FmtSubscriber::builder()
-        .with_target(false)
-        .finish();
+    let registry = tracing_subscriber::Registry::default()
+        .with(filter)
+        .with(format_layer);
 
     #[cfg(all(feature = "console", tokio_unstable))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "console")))]
     {
         let console_layer = console_subscriber::ConsoleLayer::builder()
-            .retention(Duration::from_secs(60))
+            .retention(std::time::Duration::from_secs(60))
             .spawn();
 
         registry.with(console_layer).init();

--- a/homestar-runtime/src/network/mod.rs
+++ b/homestar-runtime/src/network/mod.rs
@@ -10,3 +10,5 @@ pub mod ipfs;
 pub mod pubsub;
 pub mod swarm;
 pub mod ws;
+
+pub use eventloop::EventLoop;

--- a/homestar-runtime/src/network/pubsub.rs
+++ b/homestar-runtime/src/network/pubsub.rs
@@ -24,6 +24,9 @@ pub fn new(keypair: Keypair, settings: &settings::Node) -> Result<gossipsub::Beh
 
     let gossipsub_config = ConfigBuilder::default()
         .heartbeat_interval(Duration::from_secs(settings.network.pubsub_heartbeat_secs))
+        .idle_timeout(Duration::from_secs(
+            settings.network.pubsub_idle_timeout_secs,
+        ))
         // This sets the kind of message validation. The default is Strict (enforce message signing).
         .validation_mode(ValidationMode::Strict)
         .mesh_n_low(1)
@@ -31,6 +34,10 @@ pub fn new(keypair: Keypair, settings: &settings::Node) -> Result<gossipsub::Beh
         .mesh_n(2)
         // Content-address messages. No two messages of the same content will be propagated.
         .message_id_fn(message_id_fn)
+        .duplicate_cache_time(Duration::from_secs(
+            settings.network.pubsub_duplication_cache_secs,
+        ))
+        .support_floodsub()
         .build()
         .map_err(anyhow::Error::msg)?;
 

--- a/homestar-runtime/src/settings.rs
+++ b/homestar-runtime/src/settings.rs
@@ -51,10 +51,16 @@ pub(crate) struct Network {
     /// [Swarm]: libp2p::swarm::Swarm
     #[serde(with = "http_serde::uri")]
     pub(crate) listen_address: Uri,
+    /// Pub/sub duplicate cache time.
+    pub(crate) pubsub_duplication_cache_secs: u64,
     /// Pub/sub hearbeat interval for mesh configuration.
     pub(crate) pubsub_heartbeat_secs: u64,
+    /// Pub/sub idle timeout
+    pub(crate) pubsub_idle_timeout_secs: u64,
     /// Quorum for receipt records on the DHT.
     pub(crate) receipt_quorum: usize,
+    /// Transport connection timeout.
+    pub(crate) transport_connection_timeout_secs: u64,
     /// Websocket-server host address.
     #[serde(with = "http_serde::uri")]
     pub(crate) websocket_host: Uri,
@@ -63,6 +69,10 @@ pub(crate) struct Network {
     /// Number of *bounded* clients to send messages to, used for a
     /// [tokio::sync::broadcast::channel]
     pub(crate) websocket_capacity: usize,
+    /// Quorum for [workflow::Info] records on the DHT.
+    ///
+    /// [workflow::Info]: crate::workflow::Info
+    pub(crate) workflow_quorum: usize,
 }
 
 /// Database-related settings for a homestar node.
@@ -79,11 +89,15 @@ impl Default for Network {
         Self {
             events_buffer_len: 100,
             listen_address: Uri::from_static("/ip4/0.0.0.0/tcp/0"),
-            pubsub_heartbeat_secs: 10,
+            pubsub_duplication_cache_secs: 1,
+            pubsub_heartbeat_secs: 60,
+            pubsub_idle_timeout_secs: 60 * 60 * 24,
             receipt_quorum: 2,
+            transport_connection_timeout_secs: 20,
             websocket_host: Uri::from_static("127.0.0.1"),
             websocket_port: 1337,
             websocket_capacity: 100,
+            workflow_quorum: 3,
         }
     }
 }

--- a/homestar-runtime/src/workflow.rs
+++ b/homestar-runtime/src/workflow.rs
@@ -22,10 +22,10 @@ use url::Url;
 
 mod info;
 pub(crate) mod settings;
-pub use info::Info;
+pub use info::{Info, WORKFLOW_TAG};
 pub(crate) use info::{Stored, StoredReceipt};
 #[allow(unused_imports)]
-pub(crate) use settings::Settings;
+pub use settings::Settings;
 
 type Dag<'a> = dagga::Dag<Vertex<'a>, usize>;
 

--- a/homestar-runtime/src/workflow/settings.rs
+++ b/homestar-runtime/src/workflow/settings.rs
@@ -9,6 +9,7 @@ pub struct Settings {
     pub(crate) retry_backoff_strategy: BackoffStrategy,
     pub(crate) retry_max_delay_secs: u64,
     pub(crate) retry_initial_delay_ms: u64,
+    pub(crate) p2p_check_timeout_secs: u64,
     pub(crate) p2p_timeout_secs: u64,
 }
 
@@ -20,7 +21,8 @@ impl Default for Settings {
             retry_backoff_strategy: BackoffStrategy::Exponential,
             retry_max_delay_secs: 60,
             retry_initial_delay_ms: 500,
-            p2p_timeout_secs: 60,
+            p2p_check_timeout_secs: 5,
+            p2p_timeout_secs: 120,
         }
     }
 }
@@ -33,6 +35,7 @@ impl Default for Settings {
             retry_backoff_strategy: BackoffStrategy::Exponential,
             retry_max_delay_secs: 1,
             retry_initial_delay_ms: 50,
+            p2p_check_timeout_secs: 1,
             p2p_timeout_secs: 1,
         }
     }

--- a/homestar-wasm/Cargo.toml
+++ b/homestar-wasm/Cargo.toml
@@ -22,13 +22,13 @@ doctest = true
 # return to version.workspace = true after the following issue is fixed:
 # https://github.com/DevinR528/cargo-sort/issues/47
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 atomic_refcell = "0.1"
 enum-as-inner = { workspace = true }
 heck = "0.4"
 homestar-core = { version = "0.1", path = "../homestar-core" }
 itertools = "0.10"
-libipld = "0.16"
-libipld-core = { version = "0.16", features = ["serde-codec", "serde"] }
+libipld = { workspace = true }
 rust_decimal = "1.30"
 stacker = "0.1"
 thiserror = { workspace = true }
@@ -43,7 +43,7 @@ wit-component = "0.8"
 [dev-dependencies]
 criterion = "0.5"
 image = "0.24"
-serde_ipld_dagcbor = "0.3"
+serde_ipld_dagcbor = { workspace = true }
 tokio = { workspace = true }
 
 [features]

--- a/homestar-wasm/src/wasmtime/config.rs
+++ b/homestar-wasm/src/wasmtime/config.rs
@@ -1,10 +1,13 @@
 //! Configuration for Wasm/wasmtime execution.
 
-use crate::wasmtime;
-use homestar_core::workflow::config::Resources;
+use crate::wasmtime::{self, limits::StoreLimitsAsync};
+use homestar_core::{consts, workflow::config::Resources};
 
 impl From<Resources> for wasmtime::State {
     fn from(resources: Resources) -> wasmtime::State {
-        wasmtime::State::new(resources.fuel().unwrap_or(u64::MAX))
+        wasmtime::State::new(
+            resources.fuel().unwrap_or(u64::MAX),
+            StoreLimitsAsync::new(Some(consts::WASM_MAX_MEMORY as usize), None),
+        )
     }
 }

--- a/homestar-wasm/src/wasmtime/limits.rs
+++ b/homestar-wasm/src/wasmtime/limits.rs
@@ -1,0 +1,66 @@
+//! Provides `async` limits for a [wasmtime::Store].
+//! This type is created for use with [wasmtime::Store::limiter_async].
+//!
+//! This is a convenience type included to avoid needing to implement the
+//! [wasmtime::ResourceLimiterAsync] trait.
+
+use async_trait::async_trait;
+use homestar_core::consts;
+use wasmtime::ResourceLimiterAsync;
+
+/// Async implementation of [wasmtime::StoreLimits].
+///
+/// Used to limit the memory use and table size of each Instance
+#[derive(Clone, Debug, PartialEq)]
+pub struct StoreLimitsAsync {
+    max_memory_size: Option<usize>,
+    max_table_elements: Option<u32>,
+    memory_consumed: u64,
+}
+
+impl Default for StoreLimitsAsync {
+    fn default() -> Self {
+        Self {
+            max_memory_size: Some(consts::WASM_MAX_MEMORY as usize),
+            max_table_elements: None,
+            memory_consumed: 0,
+        }
+    }
+}
+
+#[async_trait]
+impl ResourceLimiterAsync for StoreLimitsAsync {
+    async fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> bool {
+        let can_grow = !matches!(self.max_memory_size, Some(limit) if desired > limit);
+        if can_grow {
+            self.memory_consumed =
+                (self.memory_consumed as i64 + (desired as i64 - current as i64)) as u64;
+        }
+        can_grow
+    }
+
+    async fn table_growing(&mut self, _current: u32, desired: u32, _maximum: Option<u32>) -> bool {
+        !matches!(self.max_table_elements, Some(limit) if desired > limit)
+    }
+}
+
+impl StoreLimitsAsync {
+    /// Create a new instance of [StoreLimitsAsync].
+    pub fn new(max_memory_size: Option<usize>, max_table_elements: Option<u32>) -> Self {
+        Self {
+            max_memory_size,
+            max_table_elements,
+            memory_consumed: 0,
+        }
+    }
+
+    /// How much memory has been consumed in bytes
+    pub fn memory_consumed(&self) -> u64 {
+        self.memory_consumed
+    }
+}

--- a/homestar-wasm/src/wasmtime/mod.rs
+++ b/homestar-wasm/src/wasmtime/mod.rs
@@ -7,6 +7,7 @@
 pub mod config;
 mod error;
 pub mod ipld;
+pub mod limits;
 pub mod world;
 
 pub use error::*;


### PR DESCRIPTION
Includes:

* match found records via "capsule" types use dagcborcodec
* runtime cleanup
* leverage shorter p2p timeout when building scheduler to check network
* remove some clones