### PR TITLE
refactor: move away from inner-join, count up unique receipts for workflow info

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688523306,
-        "narHash": "sha256-xcJHmwlw0w05D/c8oPX6COxVLYNbu6lXF2mIV7dFGkc=",
+        "lastModified": 1688956120,
+        "narHash": "sha256-7geHGr2aLpQvwGgaZlTLPHMVFxvFzAuB35mZYsKgLpQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "023b1df882979a413a3f7e2009424db30d51a0fe",
+        "rev": "2169d3b0bce0daa64d05abbdf9da552a7b8c22a7",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688524421,
-        "narHash": "sha256-EFauqXKKjbJKPWv3kbzl1lm1GnXl0+DBK4RcLuFndZQ=",
+        "lastModified": 1688956505,
+        "narHash": "sha256-6sa19mHTkdOi867lIolhpiS20trMdo0unk5/37859X4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ab050286f18ea354bfe7a49ca8ddcbd633cae1ca",
+        "rev": "4acc04c26df84e0a718c3efe4e13021222d23b28",
         "type": "github"
       },
       "original": {

--- a/homestar-runtime/src/db.rs
+++ b/homestar-runtime/src/db.rs
@@ -171,7 +171,7 @@ pub trait Database: Send + Sync + Clone {
         Ok(wf)
     }
 
-    /// Return orkflow information with number of receipts emitted.
+    /// Return workflow information with number of receipts emitted.
     fn get_workflow_info(workflow_cid: Cid, conn: &mut Connection) -> Result<workflow::Info> {
         let wf = Self::select_workflow(workflow_cid, conn)?;
         let associated_receipts = workflow::StoredReceipt::belonging_to(&wf)

--- a/homestar-runtime/src/runner.rs
+++ b/homestar-runtime/src/runner.rs
@@ -241,15 +241,13 @@ mod test {
         time::Duration,
     };
 
-    static ATOMIC_PORT: AtomicUsize = AtomicUsize::new(1338);
+    static ATOMIC_PORT: AtomicUsize = AtomicUsize::new(444);
 
     async fn setup() -> Runner {
         let mut settings = Settings::load().unwrap();
-        settings.node.network.websocket_port = ATOMIC_PORT.fetch_add(1, Ordering::SeqCst) as u16;
-        let db = crate::test_utils::db::MemoryDb::setup_connection_pool(
-            Settings::load().unwrap().node(),
-        )
-        .unwrap();
+        let _ = ATOMIC_PORT.fetch_add(1, Ordering::SeqCst) as u16;
+        settings.node.network.websocket_port = ATOMIC_PORT.load(Ordering::SeqCst) as u16;
+        let db = crate::test_utils::db::MemoryDb::setup_connection_pool(settings.node()).unwrap();
 
         Runner::start(settings.into(), db).await.unwrap()
     }

--- a/homestar-runtime/src/worker.rs
+++ b/homestar-runtime/src/worker.rs
@@ -17,7 +17,7 @@ use crate::{
         Event,
     },
     network::swarm::CapsuleTag,
-    runner::{ModifiedSet, RunningSet},
+    runner::{ModifiedSet, RunningTaskSet},
     scheduler::TaskScheduler,
     tasks::{RegisteredTasks, WasmContext},
     workflow::{self, Resource},
@@ -138,7 +138,7 @@ impl<'a> Worker<'a> {
     pub(crate) async fn run(
         self,
         db: impl Database + Sync,
-        running_set: &mut RunningSet,
+        running_set: &mut RunningTaskSet,
     ) -> Result<()> {
         self.run_queue(db, running_set).await
     }
@@ -146,7 +146,7 @@ impl<'a> Worker<'a> {
     async fn run_queue(
         mut self,
         db: impl Database + Sync,
-        running_set: &mut RunningSet,
+        running_set: &mut RunningTaskSet,
     ) -> Result<()> {
         fn insert_into_map<T>(mut map: Arc<LinkMap<T>>, key: Cid, value: T)
         where

--- a/homestar-runtime/src/workflow/info.rs
+++ b/homestar-runtime/src/workflow/info.rs
@@ -52,7 +52,9 @@ impl Stored {
 ///
 /// [Workflow]: homestar_core::Workflow
 /// [receipts]: crate::Receipt
-#[derive(Debug, Clone, PartialEq, Queryable, Insertable, Identifiable, Associations, Hash)]
+#[derive(
+    Debug, Clone, PartialEq, Queryable, Insertable, Identifiable, Selectable, Associations, Hash,
+)]
 #[diesel(belongs_to(Receipt, foreign_key = receipt_cid))]
 #[diesel(belongs_to(Stored, foreign_key = workflow_cid))]
 #[diesel(table_name = crate::db::schema::workflows_receipts, primary_key(workflow_cid, receipt_cid))]
@@ -171,6 +173,7 @@ impl Info {
     ) -> Result<Self> {
         let workflow_len = workflow.len();
         let workflow_cid = workflow.to_cid()?;
+
         let handle_timeout_fn = |workflow_cid, reused_conn: Option<&'a mut Connection>| {
             let workflow_info = Self::default(workflow_cid, workflow_len);
             // store workflow from info
@@ -234,6 +237,8 @@ impl Info {
                             ),
                             conn,
                         )?;
+
+                        Db::store_workflow_receipts(workflow_cid, &workflow_info.progress, conn)?;
                     }
 
                     Ok(workflow_info)


### PR DESCRIPTION
## Description

This PR essentially makes progress count monotonic by changing up the inner join and storing receipt cids when grabbing info over libp2p.


## Type of change

- [X] Refactor (non-breaking change that updates existing functionality)