### PR TITLE
refactor: for mdns, do not add explicit peer, just add to kademlia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,11 +793,8 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1476,7 +1473,7 @@ dependencies = [
  "diesel_derives",
  "libsqlite3-sys",
  "r2d2",
- "time 0.3.25",
+ "time",
 ]
 
 [[package]]
@@ -2408,7 +2405,7 @@ dependencies = [
  "tabled",
  "tarpc",
  "thiserror",
- "time 0.3.25",
+ "time",
  "tokio",
  "tokio-serde",
  "tokio-tungstenite",
@@ -4737,7 +4734,7 @@ dependencies = [
  "natord",
  "once_cell",
  "puffin",
- "time 0.3.25",
+ "time",
  "vec1",
 ]
 
@@ -5522,7 +5519,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.25",
+ "time",
 ]
 
 [[package]]
@@ -6184,17 +6181,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
@@ -6474,7 +6460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.25",
+ "time",
  "tracing-subscriber",
 ]
 
@@ -6516,7 +6502,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2fb2783ed7727b30a78ebecb49d59c98102b1f384105aa27d632487875a67b"
 dependencies = [
- "time 0.3.25",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -6899,12 +6885,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = { version = "1.0", features = ["backtrace"] }
 async-trait = "0.1"
 atomic_refcell = "0.1"
 byte-unit = { version = "4.0", default-features = false }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 enum-assoc = " 1.1"
 enum-as-inner = "0.6"
 futures = "0.3"

--- a/homestar-runtime/src/event_handler/swarm_event.rs
+++ b/homestar-runtime/src/event_handler/swarm_event.rs
@@ -341,23 +341,23 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
             }
         },
         SwarmEvent::Behaviour(ComposedEvent::Mdns(mdns::Event::Discovered(list))) => {
-            for (peer_id, _multiaddr) in list {
+            for (peer_id, multiaddr) in list {
                 info!("mDNS discovered a new peer: {peer_id}");
                 event_handler
                     .swarm
                     .behaviour_mut()
-                    .gossipsub
-                    .add_explicit_peer(&peer_id);
+                    .kademlia
+                    .add_address(&peer_id, multiaddr);
             }
         }
         SwarmEvent::Behaviour(ComposedEvent::Mdns(mdns::Event::Expired(list))) => {
-            for (peer_id, _multiaddr) in list {
+            for (peer_id, multiaddr) in list {
                 info!("mDNS discover peer has expired: {peer_id}");
                 event_handler
                     .swarm
                     .behaviour_mut()
-                    .gossipsub
-                    .remove_explicit_peer(&peer_id);
+                    .kademlia
+                    .remove_address(&peer_id, &multiaddr);
             }
         }
         SwarmEvent::NewListenAddr { address, .. } => {

--- a/homestar-runtime/src/event_handler/swarm_event.rs
+++ b/homestar-runtime/src/event_handler/swarm_event.rs
@@ -353,11 +353,13 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
         SwarmEvent::Behaviour(ComposedEvent::Mdns(mdns::Event::Expired(list))) => {
             for (peer_id, multiaddr) in list {
                 info!("mDNS discover peer has expired: {peer_id}");
-                event_handler
-                    .swarm
-                    .behaviour_mut()
-                    .kademlia
-                    .remove_address(&peer_id, &multiaddr);
+                if event_handler.swarm.behaviour_mut().mdns.has_node(&peer_id) {
+                    event_handler
+                        .swarm
+                        .behaviour_mut()
+                        .kademlia
+                        .remove_address(&peer_id, &multiaddr);
+                }
             }
         }
         SwarmEvent::NewListenAddr { address, .. } => {

--- a/homestar-runtime/src/network/swarm.rs
+++ b/homestar-runtime/src/network/swarm.rs
@@ -47,7 +47,14 @@ pub(crate) async fn new(settings: &settings::Node) -> Result<Swarm<ComposedBehav
                 )],
                 request_response::Config::default(),
             ),
-            mdns: mdns::Behaviour::new(mdns::Config::default(), peer_id)?,
+            mdns: mdns::Behaviour::new(
+                mdns::Config {
+                    ttl: settings.network.mdns_ttl,
+                    query_interval: settings.network.mdns_query_interval,
+                    enable_ipv6: settings.network.mdns_enable_ipv6,
+                },
+                peer_id,
+            )?,
         },
         peer_id,
     )

--- a/homestar-runtime/src/settings.rs
+++ b/homestar-runtime/src/settings.rs
@@ -72,6 +72,14 @@ pub struct Network {
     /// [Swarm]: libp2p::swarm::Swarm
     #[serde(with = "http_serde::uri")]
     pub(crate) listen_address: Uri,
+    /// Mdns IPv6 enable flag.
+    pub(crate) mdns_enable_ipv6: bool,
+    /// Mdns query interval.
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub(crate) mdns_query_interval: Duration,
+    /// Mdns TTL.
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub(crate) mdns_ttl: Duration,
     /// Timeout for p2p requests for a provided record.
     #[serde_as(as = "DurationSeconds<u64>")]
     pub(crate) p2p_provider_timeout: Duration,
@@ -146,6 +154,9 @@ impl Default for Network {
         Self {
             events_buffer_len: 100,
             listen_address: Uri::from_static("/ip4/0.0.0.0/tcp/0"),
+            mdns_enable_ipv6: true,
+            mdns_query_interval: Duration::from_secs(5 * 60),
+            mdns_ttl: Duration::from_secs(60 * 9),
             p2p_provider_timeout: Duration::new(30, 0),
             pubsub_duplication_cache_time: Duration::new(1, 0),
             pubsub_heartbeat: Duration::new(60, 0),


### PR DESCRIPTION
# Description

As per a convo with @mriise, we should not add mdns peers as explicit peers. Instead, add them to kademlia. 