### PR TITLE
Feat: Add capture for windows signals

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest, macos-latest]
     if: >
       github.ref == 'refs/heads/main' &&
       github.repository_owner == 'ipvm-wg' &&

--- a/.github/workflows/tests_and_checks.yml
+++ b/.github/workflows/tests_and_checks.yml
@@ -16,12 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust-toolchain:
           - stable
           - nightly
           # minimum version
-          - 1.67
+          # 1.68 fixes: https://github.com/rust-lang/cargo/pull/11347
+          - 1.68
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 edition = "2021"
 license = "Apache"
-rust-version = "1.67.0"
+rust-version = "1.68"
 
 [workspace.dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }

--- a/homestar-runtime/fixtures/test_v4.toml
+++ b/homestar-runtime/fixtures/test_v4.toml
@@ -1,0 +1,9 @@
+[monitoring]
+process_collector_interval = 10
+
+[node]
+
+[node.network]
+events_buffer_len = 1000
+rpc_port = 9999
+rpc_host = "127.0.0.1"

--- a/homestar-runtime/src/daemon.rs
+++ b/homestar-runtime/src/daemon.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 use std::path::PathBuf;
 
+#[cfg(not(windows))]
 const PID_FILE: &str = "homestar.pid";
 
 /// Start the Homestar runtime as a daemon.
@@ -18,6 +19,6 @@ pub fn start(dir: PathBuf) -> Result<()> {
 
 /// Start the Homestar runtime as a daemon.
 #[cfg(windows)]
-pub fn start(dir: PathBuf) -> Result<()> {
+pub fn start(_dir: PathBuf) -> Result<()> {
     Err(anyhow::anyhow!("Daemonizing is not supported on Windows"))
 }

--- a/homestar-runtime/tests/cli.rs
+++ b/homestar-runtime/tests/cli.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use assert_cmd::{crate_name, prelude::*};
+#[cfg(not(windows))]
 use nix::{
     sys::signal::{self, Signal},
     unistd::Pid,
@@ -9,13 +10,12 @@ use predicates::prelude::*;
 use retry::{delay::Fixed, retry};
 use serial_test::serial;
 use std::{
-    fs,
-    net::{IpAddr, Ipv6Addr, Shutdown, SocketAddr, TcpStream},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, TcpStream},
     path::PathBuf,
     process::{Command, Stdio},
     time::Duration,
 };
-use sysinfo::{PidExt, ProcessExt, SystemExt};
+use sysinfo::{ProcessExt, SystemExt};
 use wait_timeout::ChildExt;
 
 static BIN: Lazy<PathBuf> = Lazy::new(|| assert_cmd::cargo::cargo_bin(crate_name!()));
@@ -87,7 +87,10 @@ fn test_server_not_running_serial() -> Result<()> {
         .arg("ping")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Connection refused"));
+        .stderr(
+            predicate::str::contains("Connection refused")
+                .or(predicate::str::contains("No connection could be made")),
+        );
 
     Command::new(BIN.as_os_str())
         .arg("ping")
@@ -95,7 +98,10 @@ fn test_server_not_running_serial() -> Result<()> {
         .arg("::1")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Connection refused"));
+        .stderr(
+            predicate::str::contains("Connection refused")
+                .or(predicate::str::contains("No connection could be made")),
+        );
 
     Command::new(BIN.as_os_str())
         .arg("ping")
@@ -105,7 +111,8 @@ fn test_server_not_running_serial() -> Result<()> {
         .failure()
         .stderr(
             predicate::str::contains("No route to host")
-                .or(predicate::str::contains("Network is unreachable")),
+                .or(predicate::str::contains("Network is unreachable")
+                    .or(predicate::str::contains("unreachable network"))),
         );
 
     Command::new(BIN.as_os_str())
@@ -114,7 +121,8 @@ fn test_server_not_running_serial() -> Result<()> {
         .failure()
         .stderr(
             predicate::str::contains("Connection refused")
-                .or(predicate::str::contains("server was already shutdown")),
+                .or(predicate::str::contains("server was already shutdown")
+                    .or(predicate::str::contains("No connection could be made"))),
         );
     let _ = stop_bin();
 
@@ -164,7 +172,10 @@ fn test_server_serial() -> Result<()> {
         .arg("9999")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Connection refused"));
+        .stderr(
+            predicate::str::contains("Connection refused")
+                .or(predicate::str::contains("No connection could be made")),
+        );
 
     let _ = Command::new(BIN.as_os_str()).arg("stop").output();
 
@@ -192,7 +203,7 @@ fn test_workflow_run_serial() -> Result<()> {
         .arg("start")
         .arg("--db")
         .arg("homestar.db")
-        //.stdout(Stdio::piped())
+        .stdout(Stdio::piped())
         .spawn()
         .unwrap();
 
@@ -257,6 +268,9 @@ fn test_workflow_run_serial() -> Result<()> {
 #[serial]
 #[cfg(not(windows))]
 fn test_daemon_serial() -> Result<()> {
+    use std::fs;
+    use sysinfo::PidExt;
+
     let _ = stop_bin();
 
     Command::new(BIN.as_os_str())
@@ -295,6 +309,162 @@ fn test_daemon_serial() -> Result<()> {
         .assert()
         .success()
         .stdout(predicate::str::contains("::1"))
+        .stdout(predicate::str::contains("pong"));
+
+    let _result = signal::kill(Pid::from_raw(pid.try_into().unwrap()), Signal::SIGTERM);
+    let _result = retry(Fixed::from_millis(500), || {
+        Command::new(BIN.as_os_str())
+            .arg("ping")
+            .assert()
+            .try_failure()
+    });
+
+    let _ = stop_bin();
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[cfg(windows)]
+fn test_signal_kill_serial() -> Result<()> {
+    let _ = stop_bin();
+
+    Command::new(BIN.as_os_str())
+        .arg("start")
+        .arg("--db")
+        .arg("homestar.db")
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let system = sysinfo::System::new_all();
+    let pid = system
+        .processes_by_exact_name("homestar-runtime.exe")
+        .collect::<Vec<_>>()
+        .first()
+        .map(|x| x.pid())
+        .unwrap();
+
+    let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 3030);
+    let result = retry(Fixed::from_millis(500), || {
+        TcpStream::connect(socket).map(|stream| stream.shutdown(Shutdown::Both))
+    });
+
+    if result.is_err() {
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
+    Command::new(BIN.as_os_str())
+        .arg("ping")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("::1"))
+        .stdout(predicate::str::contains("pong"));
+
+    if let Some(process) = system.process(pid) {
+        process.kill();
+    };
+
+    Command::new(BIN.as_os_str()).arg("ping").assert().failure();
+    let _ = stop_bin();
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[cfg(windows)]
+fn test_server_v4_serial() -> Result<()> {
+    let _ = stop_bin();
+
+    let mut homestar_proc = Command::new(BIN.as_os_str())
+        .arg("start")
+        .arg("-c")
+        .arg("fixtures/test_v4.toml")
+        .arg("--db")
+        .arg("homestar.db")
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9999);
+    let result = retry(Fixed::from_millis(500), || {
+        TcpStream::connect(socket).map(|stream| stream.shutdown(Shutdown::Both))
+    });
+
+    if result.is_err() {
+        homestar_proc.kill().unwrap();
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
+    Command::new(BIN.as_os_str())
+        .arg("ping")
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("-p")
+        .arg("9999")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("127.0.0.1"))
+        .stdout(predicate::str::contains("pong"));
+
+    let _ = stop_bin();
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[cfg(not(windows))]
+fn test_daemon_v4_serial() -> Result<()> {
+    use std::fs;
+    use sysinfo::PidExt;
+
+    let _ = stop_bin();
+
+    Command::new(BIN.as_os_str())
+        .arg("start")
+        .arg("-c")
+        .arg("fixtures/test_v4.toml")
+        .arg("-d")
+        .env("DATABASE_URL", "homestar.db")
+        .stdout(Stdio::piped())
+        .assert()
+        .success();
+
+    let system = sysinfo::System::new_all();
+    let pid = system
+        .processes_by_exact_name("homestar-runtime")
+        .collect::<Vec<_>>()
+        .first()
+        .map(|p| p.pid().as_u32())
+        .unwrap_or(
+            fs::read_to_string("/tmp/homestar.pid")
+                .expect("Should have a PID file")
+                .trim()
+                .parse::<u32>()
+                .unwrap(),
+        );
+
+    let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9999);
+    let result = retry(Fixed::from_millis(500), || {
+        TcpStream::connect(socket).map(|stream| stream.shutdown(Shutdown::Both))
+    });
+
+    if result.is_err() {
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
+    Command::new(BIN.as_os_str())
+        .arg("ping")
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("-p")
+        .arg("9999")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("127.0.0.1"))
         .stdout(predicate::str::contains("pong"));
 
     let _result = signal::kill(Pid::from_raw(pid.try_into().unwrap()), Signal::SIGTERM);


### PR DESCRIPTION
# Description

Adds code to capture windows signals in the runtime. Includes tests for starting and killing the runtime, also includes a change so github actions will build a windows container.

## Link to issue

Fixes: [#183]

## Type of change
- [X] New feature (non-breaking change that adds functionality)

Please delete options that are not relevant.

## Test plan (required)
Added a few tests into the CLI around testing both windows and non-windows functionality. Includes some ipv4 testing, daemon testing and windows signal testing. 
