### PR TITLE
chore: Remove resolver setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ members = [
     "homestar-functions",
     "homestar-runtime",
     "homestar-wasm"]
-resolver = "2"
 
 [workspace.package]
 authors = [
@@ -22,7 +21,7 @@ async-trait = "0.1"
 atomic_refcell = "0.1"
 byte-unit = { version = "4.0", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-enum-assoc = " 1.1"
+enum-assoc = "1.1"
 enum-as-inner = "0.6"
 futures = "0.3"
 humantime = "2.1"


### PR DESCRIPTION
# Description

This PR implements the following changes:

- [x] Remove the `resolver` setting from the workspace `Cargo.toml`
- [x] Remove whitespace from the `enum-assoc` version

The `resolver` setting of `2` is implicit when using Rust 2021: https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

Build and run the tests. Everything should work without failures.
