### PR TITLE
feat: Improve relay app node rendering and controls

### DIFF
--- a/examples/websocket-relay/relay-app/src/components/Controls.svelte
+++ b/examples/websocket-relay/relay-app/src/components/Controls.svelte
@@ -24,10 +24,10 @@
     const { task } = event.detail;
 
     tasks[task.workflowId] = tasks[task.workflowId].map((t) => {
-      t.active = false;
+      t.selected = false;
 
       if (t.id === task.id) {
-        t.active = true;
+        t.selected = true;
       }
 
       return t;
@@ -38,7 +38,7 @@
     const { task } = event.detail;
 
     tasks[task.workflowId] = tasks[task.workflowId].map((t) => {
-      t.active = false;
+      t.selected = false;
       return t;
     });
   }

--- a/examples/websocket-relay/relay-app/src/components/controls/Task.svelte
+++ b/examples/websocket-relay/relay-app/src/components/controls/Task.svelte
@@ -61,8 +61,6 @@
     <div transition:slide={{ easing: quartOut }}>
       {#if task.receipt}
         <p class="w-52 pl-1 pt-2 text-sm text-slate-700">{task.message}</p>
-        <TaskValue label="Receipt CID" val={task.receipt.cid} />
-        <TaskValue label="Instruction" val={task.receipt.instruction} />
         <TaskValue label="Ran" val={task.receipt.ran} />
       {:else}
         <p class="w-52 pl-1 pt-2 text-sm text-slate-700">{task.message}</p>

--- a/examples/websocket-relay/relay-app/src/components/controls/Task.svelte
+++ b/examples/websocket-relay/relay-app/src/components/controls/Task.svelte
@@ -39,7 +39,7 @@
     <span class="capitalize">
       {task.operation}
     </span>
-    {#if task.active}
+    {#if task.selected}
       <span
         class="ml-auto cursor-pointer"
         on:click={() => collapse(task)}
@@ -57,7 +57,7 @@
       </span>
     {/if}
   </div>
-  {#if task.active}
+  {#if task.selected}
     <div transition:slide={{ easing: quartOut }}>
       {#if task.receipt}
         <p class="w-52 pl-1 pt-2 text-sm text-slate-700">{task.message}</p>

--- a/examples/websocket-relay/relay-app/src/components/controls/Workflow.svelte
+++ b/examples/websocket-relay/relay-app/src/components/controls/Workflow.svelte
@@ -2,15 +2,22 @@
   import { createEventDispatcher } from "svelte";
 
   import type { Workflow } from "$lib/workflow";
+  import { workflowStore } from "../../stores";
   import PlayIcon from "$components/icons/Play.svelte";
   import Spinner from "$components/icons/Spinner.svelte";
 
   export let workflow: Workflow;
 
   const dispatch = createEventDispatcher();
+  let disabled = false;
 
   function run(workflowId: string) {
     dispatch("run", { workflowId });
+  }
+
+  $: {
+    const otherId = workflow.id === "one" ? "two" : "one";
+    disabled = $workflowStore[otherId].status === "working";
   }
 </script>
 
@@ -18,15 +25,21 @@
   class="flex flex-row content-center items-center px-2 py-1.5 bg-black text-white"
 >
   <span class="capitalize">Workflow {workflow.id}</span>
-  <span
-    class="ml-auto cursor-pointer"
-    on:click={() => run(workflow.id)}
-    on:keypress={() => run(workflow.id)}
-  >
-    {#if workflow.status === "waiting"}
+  {#if disabled}
+    <span class="ml-auto cursor-not-allowed">
+      <PlayIcon disabled={true} />
+    </span>
+  {:else if workflow.status === "waiting"}
+    <span
+      class="ml-auto cursor-pointer"
+      on:click={() => run(workflow.id)}
+      on:keypress={() => run(workflow.id)}
+    >
       <PlayIcon />
-    {:else if workflow.status === "working"}
+    </span>
+  {:else if workflow.status === "working"}
+    <span class="ml-auto cursor-progress">
       <Spinner />
-    {/if}
-  </span>
+    </span>
+  {/if}
 </div>

--- a/examples/websocket-relay/relay-app/src/components/icons/Play.svelte
+++ b/examples/websocket-relay/relay-app/src/components/icons/Play.svelte
@@ -1,10 +1,14 @@
+<script lang="ts">
+  export let disabled = false;
+</script>
+
 <svg
   xmlns="http://www.w3.org/2000/svg"
   width="16"
   height="16"
   viewBox="0 0 24 24"
   fill="none"
-  stroke="currentColor"
+  stroke={disabled ? "#999999" : "currentcolor"}
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"

--- a/examples/websocket-relay/relay-app/src/lib/task.ts
+++ b/examples/websocket-relay/relay-app/src/lib/task.ts
@@ -2,7 +2,7 @@ export type Task = {
   id: number;
   workflowId: "one" | "two";
   operation: TaskOperation;
-  active: boolean;
+  selected: boolean;
   status: TaskStatus;
   message: string;
   receipt?: Receipt;

--- a/examples/websocket-relay/relay-app/src/lib/workflow.ts
+++ b/examples/websocket-relay/relay-app/src/lib/workflow.ts
@@ -148,15 +148,6 @@ export async function handleMessage(event: MessageEvent) {
       return;
     }
 
-    if (message.receipt.meta.op !== activeWorkflow.tasks[activeWorkflow.step]) {
-      console.log(message.receipt.meta.op);
-      console.log(activeWorkflow.tasks[activeWorkflow.step]);
-      console.error(
-        "Received a receipt that did not match the expected workflow step"
-      );
-      return;
-    }
-
     const taskId = activeWorkflow.step + 1;
     const status = message.metadata.replayed ? "replayed" : "executed";
     const receipt = parseReceipt(message.receipt);

--- a/examples/websocket-relay/relay-app/src/stores.ts
+++ b/examples/websocket-relay/relay-app/src/stores.ts
@@ -84,8 +84,14 @@ export const taskStore: Writable<Record<WorkflowId, Task[]>> = writable({
 export const nodeStore: Readable<NodeType[]> = derived(
   taskStore,
   ($taskStore) => {
-    const workflowOneNodes = $taskStore["one"].reduce((nodes, task, index) => {
-      if (task.status === "executed" || task.status === "replayed") {
+    const workflowOneTasks = $taskStore["one"]
+    const workflowOneNodes = workflowOneTasks.reduce((nodes, task, index) => {
+      const previous = index !== 0 ? workflowOneTasks[index - 1] : null
+
+      if (
+        (task.status === "executed" || task.status === "replayed") &&
+        (previous ? previous.status !== 'waiting' && previous.status !== "failure" : true)
+      ) {
         const idOffset = 2;
 
         // @ts-ignore
@@ -110,8 +116,14 @@ export const nodeStore: Readable<NodeType[]> = derived(
       return nodes;
     }, []);
 
-    const workflowTwoNodes = $taskStore["two"].reduce((nodes, task, index) => {
-      if (task.status === "executed" || task.status === "replayed") {
+    const workflowTwoTasks = $taskStore["two"]
+    const workflowTwoNodes = workflowTwoTasks.reduce((nodes, task, index) => {
+      const previous = index !== 0 ? workflowTwoTasks[index - 1] : null
+
+      if (
+        (task.status === "executed" || task.status === "replayed") &&
+        (previous ? previous.status !== 'waiting' && previous.status !== "failure" : true)
+      ) {
         const idOffset = 5;
 
         // Check for a matching task in workflow one

--- a/examples/websocket-relay/relay-app/src/stores.ts
+++ b/examples/websocket-relay/relay-app/src/stores.ts
@@ -33,7 +33,7 @@ export const taskStore: Writable<Record<WorkflowId, Task[]>> = writable({
       workflowId: "one",
       operation: "crop",
       message: "Waiting for task to complete",
-      active: false,
+      selected: false,
       status: "waiting",
     },
     {
@@ -41,7 +41,7 @@ export const taskStore: Writable<Record<WorkflowId, Task[]>> = writable({
       workflowId: "one",
       operation: "rotate90",
       message: "Waiting for task to complete.",
-      active: false,
+      selected: false,
       status: "waiting",
     },
     {
@@ -49,7 +49,7 @@ export const taskStore: Writable<Record<WorkflowId, Task[]>> = writable({
       workflowId: "one",
       operation: "blur",
       message: "Waiting for task to complete.",
-      active: false,
+      selected: false,
       status: "waiting",
     },
   ],
@@ -59,7 +59,7 @@ export const taskStore: Writable<Record<WorkflowId, Task[]>> = writable({
       workflowId: "two",
       operation: "crop",
       message: "Waiting for task to complete.",
-      active: false,
+      selected: false,
       status: "waiting",
     },
     {
@@ -67,7 +67,7 @@ export const taskStore: Writable<Record<WorkflowId, Task[]>> = writable({
       workflowId: "two",
       operation: "rotate90",
       message: "Waiting for task to complete.",
-      active: false,
+      selected: false,
       status: "waiting",
     },
     {
@@ -75,7 +75,7 @@ export const taskStore: Writable<Record<WorkflowId, Task[]>> = writable({
       workflowId: "two",
       operation: "grayscale",
       message: "Waiting for task to complete.",
-      active: false,
+      selected: false,
       status: "waiting",
     },
   ],


### PR DESCRIPTION
# Description

This PR implements the following changes:

- [x] Only render nodes when previous task has completed
- [x] Remove task out-of-order error case
- [x] Disable a workflow play button when the other workflow is active
- [x] Prevent multiple runs of a workflow when it is active (spinner that replaces play button is not clickable)
- [x] Rename `task.active` to `task.selected` to better indicate that this is UI state
- [x] Remove receipt and instruction CID from completed task dropdown 

We had an issue where Firefox would receive receipts over the Websocket channel nearly simultaneously which resulted in out-of-order errors. This PR fixes that by delaying the rendering of nodes until each previous task has completed and removing the error case.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor 

## Test plan (required)

The play button should be disabled when the other workflow is running. The button should not handle click events when in a spinner state.

Test in Firefox. No errors should be present and workflows should run and render as expected.

