### PR TITLE
feat: Add out-of-band node metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ private
 homestar-guest-wasm/out
 homestar-wasm/out
 **/fixtures/test_*
+.zed
+result-alejandra
+
 
 # ipfs
 .ipfs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,20 +35,12 @@ repos:
         args: ["--document-private-items"]
         types: [rust]
         pass_filenames: false
+
+  - repo: https://github.com/kamadorueda/alejandra
+    rev: bb7f2ad3f176aa8e9e2944a10061f7989c8fef17  # frozen: 1.3.0
+    hooks:
       - id: alejandra
-        name: alejandra
-        description: Format nix files.
-        entry: alejandra
         files: \.nix$
-        language: system
-      - id: taplo
-        name: taplo
-        description: Format toml files.
-        language: system
-        entry: taplo
-        args: ["fmt"]
-        types:
-          - toml
 
   - repo: https://github.com/DevinR528/cargo-sort
     rev: v1.0.9
@@ -57,9 +49,12 @@ repos:
         args: ["-w"]
 
   - repo: https://github.com/ComPWA/mirrors-taplo
-    rev: "v0.8.1"
+    rev: v0.8.1
     hooks:
       - id: taplo
+        args: ["fmt"]
+        types:
+          - toml
 
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v2.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,11 @@ repos:
       - id: cargo-sort
         args: ["-w"]
 
+  - repo: https://github.com/ComPWA/mirrors-taplo
+    rev: "v0.8.1"
+    hooks:
+      - id: taplo
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v2.1.1
     hooks:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,6 +2628,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "predicates",
+ "prometheus-parse",
  "proptest",
  "puffin",
  "puffin_egui",
@@ -5011,6 +5022,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2aa5feb83bf4b2c8919eaf563f51dbab41183de73ba2353c0e03cd7b6bd892"
+dependencies = [
+ "chrono",
+ "itertools 0.10.5",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "proptest"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5969,6 +5992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
 dependencies = [
  "dashmap",
+ "fslock",
  "futures",
  "lazy_static",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
 
 [[package]]
 name = "anstyle-parse"
@@ -322,7 +322,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -333,7 +333,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -369,7 +369,7 @@ checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -458,9 +458,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64ct"
@@ -539,24 +539,24 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
+checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.2.6",
+ "constant_time_eq",
 ]
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
+checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.2.6",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -569,7 +569,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.0",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -700,9 +700,9 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
@@ -712,9 +712,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
  "serde",
 ]
@@ -926,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.2"
+version = "4.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -955,7 +955,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1062,12 +1062,6 @@ name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "constant_time_eq"
@@ -1496,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
+checksum = "622178105f911d937a42cdb140730ba4a3ed2becd8ae6ce39c7d28b5d75d4588"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1519,7 +1513,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1564,7 +1558,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1575,7 +1569,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1682,7 +1676,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1702,7 +1696,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1780,7 +1774,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1835,7 +1829,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
- "curve25519-dalek 4.0.0",
+ "curve25519-dalek 4.1.0",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -1845,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079044df30bb07de7d846d41a184c4b00e66ebdac93ee459253474f3a47e50ae"
+checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",
@@ -1908,7 +1902,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1932,7 +1926,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -2050,7 +2044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
 dependencies = [
  "cfg-if",
- "rustix 0.38.11",
+ "rustix 0.38.13",
  "windows-sys",
 ]
 
@@ -2065,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
 
 [[package]]
 name = "file-per-thread-logger"
@@ -2160,7 +2154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d167b646a876ba8fda6b50ac645cfd96242553cbaf0ca4fccaa39afcbf0801f"
 dependencies = [
  "io-lifetimes 1.0.11",
- "rustix 0.38.11",
+ "rustix 0.38.13",
  "windows-sys",
 ]
 
@@ -2242,7 +2236,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -2463,7 +2457,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "headers-core",
  "http",
@@ -2616,9 +2610,12 @@ dependencies = [
  "libipld",
  "libp2p",
  "libsqlite3-sys",
+ "metrics",
+ "metrics-exporter-prometheus",
  "miette",
  "names",
  "nix 0.27.1",
+ "num_cpus",
  "once_cell",
  "openssl",
  "predicates",
@@ -2662,7 +2659,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -2985,7 +2982,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "widestring",
  "windows-sys",
  "winreg 0.50.0",
@@ -3056,7 +3053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.11",
+ "rustix 0.38.13",
  "windows-sys",
 ]
 
@@ -3180,9 +3177,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libipld"
@@ -3351,7 +3348,7 @@ dependencies = [
  "libp2p-identity",
  "log",
  "multiaddr 0.18.0",
- "multihash 0.19.0",
+ "multihash 0.19.1",
  "multistream-select",
  "once_cell",
  "parking_lot",
@@ -3387,7 +3384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d157562dba6017193e5285acf6b1054759e83540bfd79f75b69d6ce774c88da"
 dependencies = [
  "asynchronous-codec",
- "base64 0.21.3",
+ "base64 0.21.4",
  "byteorder",
  "bytes",
  "either",
@@ -3445,7 +3442,7 @@ dependencies = [
  "ed25519-dalek",
  "libsecp256k1",
  "log",
- "multihash 0.19.0",
+ "multihash 0.19.1",
  "quick-protobuf",
  "rand",
  "sha2 0.10.7",
@@ -3496,7 +3493,7 @@ dependencies = [
  "log",
  "rand",
  "smallvec",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio",
  "trust-dns-proto",
  "void",
@@ -3526,13 +3523,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71ce70757f2c0d82e9a3ef738fb10ea0723d16cec37f078f719e2c247704c1bb"
 dependencies = [
  "bytes",
- "curve25519-dalek 4.0.0",
+ "curve25519-dalek 4.1.0",
  "futures",
  "libp2p-core",
  "libp2p-identity",
  "log",
  "multiaddr 0.18.0",
- "multihash 0.19.0",
+ "multihash 0.19.1",
  "once_cell",
  "quick-protobuf",
  "rand",
@@ -3562,7 +3559,7 @@ dependencies = [
  "quinn",
  "rand",
  "rustls",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "thiserror",
  "tokio",
 ]
@@ -3644,7 +3641,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -3660,7 +3657,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "log",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio",
 ]
 
@@ -3789,9 +3786,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
@@ -3838,6 +3835,15 @@ name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
 dependencies = [
  "libc",
 ]
@@ -3915,6 +3921,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash 0.8.3",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
+dependencies = [
+ "base64 0.21.4",
+ "hyper",
+ "indexmap 1.9.3",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111cb375987443c3de8d503580b536f77dc8416d32db62d9456db5d93bd7ac47"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.2",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "miette"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3943,7 +4004,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -3953,7 +4014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
 dependencies = [
  "serde",
- "toml 0.7.6",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -4040,7 +4101,7 @@ dependencies = [
  "data-encoding",
  "libp2p-identity",
  "multibase",
- "multihash 0.19.0",
+ "multihash 0.19.1",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -4104,9 +4165,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd59dcc2bbe70baabeac52cd22ae52c55eefe6c38ff11a9439f16a350a939f2"
+checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
 dependencies = [
  "core2",
  "unsigned-varint",
@@ -4455,7 +4516,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -4667,7 +4728,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -4698,7 +4759,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -4822,6 +4883,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4909,14 +4976,14 @@ checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -4941,7 +5008,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -5081,6 +5148,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5162,7 +5245,7 @@ checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
 dependencies = [
  "bytes",
  "libc",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tracing",
  "windows-sys",
 ]
@@ -5239,6 +5322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5376,7 +5468,7 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -5591,14 +5683,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.11"
+version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.5",
+ "linux-raw-sys 0.4.7",
  "windows-sys",
 ]
 
@@ -5616,9 +5708,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
  "ring",
  "untrusted",
@@ -5785,7 +5877,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -5848,7 +5940,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5868,7 +5960,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -5893,7 +5985,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -6000,6 +6092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6057,7 +6155,7 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek 4.0.0",
+ "curve25519-dalek 4.1.0",
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
@@ -6077,9 +6175,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -6207,7 +6305,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -6257,9 +6355,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6344,7 +6442,7 @@ dependencies = [
  "cap-std",
  "fd-lock",
  "io-lifetimes 2.0.2",
- "rustix 0.38.11",
+ "rustix 0.38.13",
  "windows-sys",
  "winx 0.36.2",
 ]
@@ -6429,7 +6527,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.11",
+ "rustix 0.38.13",
  "windows-sys",
 ]
 
@@ -6486,7 +6584,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -6565,7 +6663,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite 0.2.13",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros",
  "tracing",
  "windows-sys",
@@ -6589,7 +6687,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -6667,9 +6765,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -6688,9 +6786,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -6707,7 +6805,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6791,7 +6889,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -6925,9 +7023,9 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33"
+checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
 
 [[package]]
 name = "tungstenite"
@@ -6974,7 +7072,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bs58",
  "cid 0.10.1",
  "futures",
@@ -7033,9 +7131,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-linebreak"
@@ -7082,9 +7180,9 @@ dependencies = [
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -7294,7 +7392,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
  "wasm-bindgen-shared",
 ]
 
@@ -7328,7 +7426,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7520,12 +7618,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d22677d863d88d0ee05a07bfe28fdc5525149b6ea5a108f1fa2796fa86d75b8"
 dependencies = [
  "anyhow",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix 0.38.11",
+ "rustix 0.38.13",
  "serde",
  "sha2 0.10.7",
  "toml 0.5.11",
@@ -7557,7 +7655,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
  "wasmtime-component-util 12.0.1",
  "wasmtime-wit-bindgen 12.0.1",
  "wit-parser 0.9.2",
@@ -7719,7 +7817,7 @@ checksum = "fcc69f0a316db37482ebc83669236ea7c943d0b49a1a23f763061c9fc9d07d0b"
 dependencies = [
  "cc",
  "cfg-if",
- "rustix 0.38.11",
+ "rustix 0.38.13",
  "wasmtime-asm-macros 12.0.1",
  "wasmtime-versioned-export-macros",
  "windows-sys",
@@ -7765,7 +7863,7 @@ dependencies = [
  "log",
  "object 0.31.1",
  "rustc-demangle",
- "rustix 0.38.11",
+ "rustix 0.38.13",
  "serde",
  "target-lexicon",
  "wasmtime-environ 12.0.1",
@@ -7792,7 +7890,7 @@ checksum = "54aa8081162b13a96f47ab40f9aa03fc02dad38ee10b1418243ac8517c5af6d3"
 dependencies = [
  "object 0.31.1",
  "once_cell",
- "rustix 0.38.11",
+ "rustix 0.38.13",
  "wasmtime-versioned-export-macros",
 ]
 
@@ -7863,7 +7961,7 @@ dependencies = [
  "memoffset 0.9.0",
  "paste",
  "rand",
- "rustix 0.38.11",
+ "rustix 0.38.13",
  "sptr",
  "wasm-encoder 0.31.1",
  "wasmtime-asm-macros 12.0.1",
@@ -7906,7 +8004,7 @@ checksum = "39ca36fa6cad8ef885bc27d7d50c8b1cb7da0534251188a824f4953b07875703"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -8382,7 +8480,7 @@ checksum = "44cea5ed784da06da0e55836a6c160e7502dbe28771c2368a595e8606243bf22"
 dependencies = [
  "anyhow",
  "proc-macro2",
- "syn 2.0.31",
+ "syn 2.0.33",
  "wit-bindgen-core",
  "wit-bindgen-rust",
  "wit-bindgen-rust-lib",
@@ -8590,7 +8688,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,7 +2615,6 @@ dependencies = [
  "miette",
  "names",
  "nix 0.27.1",
- "num_cpus",
  "once_cell",
  "openssl",
  "predicates",

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
         format-pkgs = with pkgs; [
           nixpkgs-fmt
           alejandra
+          taplo
         ];
 
         cargo-installs = with pkgs; [

--- a/homestar-runtime/Cargo.toml
+++ b/homestar-runtime/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = { workspace = true }
 documentation = "https://docs.rs/homestar"
 repository = "https://github.com/ipvm-wg/homestar"
 authors = { workspace = true }
+autotests = false
 
 [lib]
 path = "src/lib.rs"
@@ -29,6 +30,10 @@ name = "homestar-runtime"
 path = "src/main.rs"
 doc = false
 bench = false
+
+[[test]]
+name = "integration"
+path = "tests/lib.rs"
 
 [dependencies]
 # return to version.workspace = true after the following issue is fixed:
@@ -105,7 +110,7 @@ proptest = { version = "1.2", optional = true }
 puffin = { version = "0.16", optional = true }
 puffin_egui = { version = "0.22.0", optional = true }
 rand = "0.8"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["blocking", "json"] }
 sec1 = { version = "0.7", features = ["pem", "der"] }
 semver = "1.0"
 serde = { workspace = true }
@@ -151,9 +156,10 @@ homestar_runtime_proc_macro = { path = "src/test_utils/proc_macro", package = "h
 nix = { version = "0.27", features = ["signal"] }
 once_cell = "1.18"
 predicates = "3.0"
+prometheus-parse = "0.2.4"
 rand = { workspace = true }
 retry = "2.0"
-serial_test = "2.0"
+serial_test = { version = "2.0", features = ["file_locks"] }
 tokio-tungstenite = "0.20"
 wait-timeout = "0.2"
 

--- a/homestar-runtime/Cargo.toml
+++ b/homestar-runtime/Cargo.toml
@@ -100,7 +100,6 @@ metrics = { version = "0.21", optional = true }
 metrics-exporter-prometheus = { version = "0.12.1", optional = true }
 miette = { version = "5.10", features = ["fancy"] }
 names = { version = "0.14", default-features = false, optional = true }
-num_cpus = { version = "1.16", optional = true }
 openssl = { version = "0.10", features = ["vendored"] }
 proptest = { version = "1.2", optional = true }
 puffin = { version = "0.16", optional = true }
@@ -164,7 +163,7 @@ ansi-logs = ["tracing-logfmt/ansi_logs"]
 console = ["dep:console-subscriber"]
 ipfs = ["dep:ipfs-api", "dep:ipfs-api-backend-hyper"]
 metrics = ["dep:metrics", "dep:metrics-exporter-prometheus"]
-monitoring = ["metrics", "dep:num_cpus", "dep:sysinfo"]
+monitoring = ["metrics", "dep:sysinfo"]
 profile = ["dep:puffin", "dep:puffin_egui"]
 test-utils = ["dep:proptest"]
 websocket-notify = ["websocket-server", "dep:serde_json", "dep:names"]

--- a/homestar-runtime/Cargo.toml
+++ b/homestar-runtime/Cargo.toml
@@ -95,8 +95,12 @@ libp2p = { version = "0.52", default-features = false, features = [
   "websocket",
 ] }
 libsqlite3-sys = { version = "0.26", features = ["bundled"] }
+metrics = { version = "0.21", optional = true }
+# Includes http-listener feature
+metrics-exporter-prometheus = { version = "0.12.1", optional = true }
 miette = { version = "5.10", features = ["fancy"] }
 names = { version = "0.14", default-features = false, optional = true }
+num_cpus = { version = "1.16", optional = true }
 openssl = { version = "0.10", features = ["vendored"] }
 proptest = { version = "1.2", optional = true }
 puffin = { version = "0.16", optional = true }
@@ -111,6 +115,7 @@ serde_json = { version = "1.0", optional = true, features = ["raw_value"] }
 serde_with = { version = "3.3", features = ["base64"] }
 stream-cancel = "0.8"
 strum = { version = "0.25", features = ["derive"] }
+sysinfo = { version = "0.29", optional = true }
 tabled = { version = "0.14", features = ["std"] }
 tarpc = { version = "0.33", features = [
   "serde-transport",
@@ -150,15 +155,16 @@ predicates = "3.0"
 rand = { workspace = true }
 retry = "2.0"
 serial_test = "2.0"
-sysinfo = "0.29"
 tokio-tungstenite = "0.20"
 wait-timeout = "0.2"
 
 [features]
-default = ["ipfs", "websocket-notify"]
+default = ["ipfs", "monitoring", "websocket-notify"]
 ansi-logs = ["tracing-logfmt/ansi_logs"]
 console = ["dep:console-subscriber"]
 ipfs = ["dep:ipfs-api", "dep:ipfs-api-backend-hyper"]
+metrics = ["dep:metrics", "dep:metrics-exporter-prometheus"]
+monitoring = ["metrics", "dep:num_cpus", "dep:sysinfo"]
 profile = ["dep:puffin", "dep:puffin_egui"]
 test-utils = ["dep:proptest"]
 websocket-notify = ["websocket-server", "dep:serde_json", "dep:names"]

--- a/homestar-runtime/config/settings.toml
+++ b/homestar-runtime/config/settings.toml
@@ -1,4 +1,5 @@
 [monitoring]
-process_collector_interval = 10
+process_collector_interval = 5
+metrics_port = 4000
 
 [node]

--- a/homestar-runtime/config/settings.toml
+++ b/homestar-runtime/config/settings.toml
@@ -1,5 +1,5 @@
 [monitoring]
-process_collector_interval = 5
+process_collector_interval = 5000
 metrics_port = 4000
 
 [node]

--- a/homestar-runtime/src/db.rs
+++ b/homestar-runtime/src/db.rs
@@ -25,7 +25,7 @@ use tracing::info;
 pub mod schema;
 pub(crate) mod utils;
 
-const ENV: &str = "DATABASE_URL";
+pub(crate) const ENV: &str = "DATABASE_URL";
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations/");
 const PRAGMAS: &str = "
 PRAGMA journal_mode = WAL;          -- better write-concurrency

--- a/homestar-runtime/src/lib.rs
+++ b/homestar-runtime/src/lib.rs
@@ -39,6 +39,7 @@ pub mod test_utils;
 pub use db::Db;
 pub use event_handler::channel;
 pub use logger::*;
+pub(crate) mod metrics;
 pub use receipt::{Receipt, RECEIPT_TAG, VERSION_KEY};
 pub use runner::Runner;
 pub use settings::Settings;

--- a/homestar-runtime/src/metrics.rs
+++ b/homestar-runtime/src/metrics.rs
@@ -7,6 +7,7 @@ use tokio::runtime::Handle;
 mod exporter;
 mod node;
 
+/// Start metrics collection and setup scrape endpoint.
 pub(crate) async fn start(settings: &settings::Monitoring) -> Result<()> {
     let handle = Handle::current();
     exporter::setup_metrics_recorder(settings)?;

--- a/homestar-runtime/src/metrics.rs
+++ b/homestar-runtime/src/metrics.rs
@@ -1,0 +1,19 @@
+//! Collect metrics and monitoring endpoint for Prometheus
+
+use crate::settings;
+use anyhow::Result;
+use tokio::runtime::Handle;
+
+mod exporter;
+mod node;
+
+pub(crate) async fn start(settings: &settings::Monitoring) -> Result<()> {
+    let handle = Handle::current();
+    exporter::setup_metrics_recorder(settings)?;
+
+    // Spawn tick-driven process collection task
+    #[cfg(feature = "monitoring")]
+    handle.spawn(node::collect_metrics(settings.process_collector_interval));
+
+    Ok(())
+}

--- a/homestar-runtime/src/metrics.rs
+++ b/homestar-runtime/src/metrics.rs
@@ -1,4 +1,4 @@
-//! Collect metrics and monitoring endpoint for Prometheus
+//! Collect metrics and setup recorder and scrape endpoint.
 
 use crate::settings;
 use anyhow::Result;

--- a/homestar-runtime/src/metrics/exporter.rs
+++ b/homestar-runtime/src/metrics/exporter.rs
@@ -1,0 +1,31 @@
+//! Metrics Prometheus recorder.
+
+use crate::{metrics::node, settings};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+/// Set up Prometheus buckets for matched metrics and install recorder.
+pub(crate) fn setup_metrics_recorder(settings: &settings::Monitoring) -> anyhow::Result<()> {
+    const EXPONENTIAL_SECONDS: &[f64] = &[
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+    ];
+
+    let socket = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        settings.metrics_port,
+    );
+
+    #[cfg(feature = "monitoring")]
+    node::describe();
+
+    PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            Matcher::Suffix("_duration_seconds".to_string()),
+            EXPONENTIAL_SECONDS,
+        )?
+        .with_http_listener(socket)
+        .install()
+        .expect("failed to install recorder/exporter");
+
+    Ok(())
+}

--- a/homestar-runtime/src/metrics/node.rs
+++ b/homestar-runtime/src/metrics/node.rs
@@ -1,0 +1,118 @@
+//! Node metrics, including system, process, network, and database information
+
+use anyhow::{anyhow, Context, Result};
+use metrics::{describe_gauge, Unit};
+use std::time::Duration;
+use sysinfo::{get_current_pid, CpuExt, ProcessExt, System, SystemExt};
+use tracing::{info, warn};
+
+/// Create and describe gauges for node metrics.
+pub(crate) fn describe() {
+    describe_gauge!(
+        "process_cpu_usage_percentage",
+        Unit::Percent,
+        "The CPU percentage used."
+    );
+    describe_gauge!(
+        "process_virtual_memory_bytes",
+        Unit::Bytes,
+        "The virtual memory size in bytes."
+    );
+    describe_gauge!("process_memory_bytes", Unit::Bytes, "Memory size in bytes.");
+    describe_gauge!(
+        "process_disk_total_written_bytes",
+        Unit::Bytes,
+        "The total bytes written to disk."
+    );
+    describe_gauge!(
+        "process_disk_written_bytes",
+        Unit::Bytes,
+        "The bytes written to disk."
+    );
+    describe_gauge!(
+        "process_disk_total_read_bytes",
+        Unit::Bytes,
+        "Total bytes Read from disk."
+    );
+    describe_gauge!(
+        "process_disk_read_bytes",
+        Unit::Bytes,
+        "The bytes read from disk."
+    );
+    describe_gauge!(
+        "process_disk_written_bytes",
+        Unit::Bytes,
+        "The bytes written to disk."
+    );
+    describe_gauge!(
+        "process_uptime_seconds",
+        Unit::Seconds,
+        "How much time the process has been running in seconds."
+    );
+}
+
+/// Collect node metrics on a settings-defined interval.
+pub(crate) async fn collect_metrics(interval: u64) {
+    let mut interval = tokio::time::interval(Duration::from_secs(interval));
+
+    loop {
+        interval.tick().await;
+        let sys_info = System::new();
+        if let Err(err) = get_stats(sys_info).await {
+            warn!(
+                subject = "metrics.process_collection",
+                category = "metrics",
+                "failure to get process statistics {:#?}",
+                err
+            );
+        }
+    }
+}
+
+async fn get_stats(mut sys: System) -> Result<()> {
+    let pid = get_current_pid().map_err(|e| anyhow!("no process pid found {}", e))?;
+
+    let is_process_refreshed = sys.refresh_process(pid);
+    sys.refresh_cpu();
+
+    if is_process_refreshed {
+        let proc = sys.process(pid).context("no process associated with pid")?;
+        let cpus = num_cpus::get();
+        let disk = proc.disk_usage();
+
+        // cpu-usage divided by # of cores.
+        metrics::gauge!(
+            "process_cpu_usage_percentage",
+            f64::from(sys.global_cpu_info().cpu_usage() / (cpus as f32))
+        );
+
+        // The docs for sysinfo indicate that `virtual_memory`
+        // returns in KB, but that is incorrect.
+        // See this issue: https://github.com/GuillaumeGomez/sysinfo/issues/428#issuecomment-774098021
+        // And this PR: https://github.com/GuillaumeGomez/sysinfo/pull/430/files
+        metrics::gauge!(
+            "process_virtual_memory_bytes",
+            (proc.virtual_memory()) as f64
+        );
+        metrics::gauge!("process_memory_bytes", (proc.memory() * 1_000) as f64);
+        metrics::gauge!("process_uptime_seconds", proc.run_time() as f64);
+        metrics::gauge!(
+            "process_disk_total_written_bytes",
+            disk.total_written_bytes as f64,
+        );
+        metrics::gauge!("process_disk_written_bytes", disk.written_bytes as f64);
+        metrics::gauge!(
+            "process_disk_total_read_bytes",
+            disk.total_read_bytes as f64,
+        );
+        metrics::gauge!("process_disk_read_bytes", disk.read_bytes as f64);
+    } else {
+        info!(
+            subject = "metrics.process_collection",
+            category = "metrics",
+            "failed to refresh process information, metrics may show old results"
+        );
+    }
+
+    Ok(())
+}

--- a/homestar-runtime/src/metrics/node.rs
+++ b/homestar-runtime/src/metrics/node.rs
@@ -1,64 +1,107 @@
 //! Node metrics, including system, process, network, and database information
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::Result;
 use metrics::{describe_gauge, Unit};
 use std::time::Duration;
-use sysinfo::{get_current_pid, CpuExt, ProcessExt, System, SystemExt};
+use sysinfo::{CpuRefreshKind, Disk, DiskExt, ProcessRefreshKind, RefreshKind, System, SystemExt};
 use tracing::{info, warn};
 
 /// Create and describe gauges for node metrics.
 pub(crate) fn describe() {
+    // System metrics
     describe_gauge!(
-        "process_cpu_usage_percentage",
+        "system_available_memory",
+        Unit::Bytes,
+        "The amount of available memory."
+    );
+    describe_gauge!(
+        "system_used_memory",
+        Unit::Bytes,
+        "The amount of used memory."
+    );
+    describe_gauge!(
+        "system_free_swap",
+        Unit::Bytes,
+        "The amount of free swap space."
+    );
+    describe_gauge!(
+        "system_used_swap",
+        Unit::Bytes,
+        "The amount of used swap space."
+    );
+    describe_gauge!(
+        "system_disk_available_space",
+        Unit::Bytes,
+        "The total amount of available disk space."
+    );
+    describe_gauge!("system_uptime", Unit::Seconds, "The total system uptime.");
+    describe_gauge!(
+        "system_load_average",
         Unit::Percent,
-        "The CPU percentage used."
+        "The load average over a five minute interval."
     );
-    describe_gauge!(
-        "process_virtual_memory_bytes",
-        Unit::Bytes,
-        "The virtual memory size in bytes."
-    );
-    describe_gauge!("process_memory_bytes", Unit::Bytes, "Memory size in bytes.");
-    describe_gauge!(
-        "process_disk_total_written_bytes",
-        Unit::Bytes,
-        "The total bytes written to disk."
-    );
-    describe_gauge!(
-        "process_disk_written_bytes",
-        Unit::Bytes,
-        "The bytes written to disk."
-    );
-    describe_gauge!(
-        "process_disk_total_read_bytes",
-        Unit::Bytes,
-        "Total bytes Read from disk."
-    );
-    describe_gauge!(
-        "process_disk_read_bytes",
-        Unit::Bytes,
-        "The bytes read from disk."
-    );
-    describe_gauge!(
-        "process_disk_written_bytes",
-        Unit::Bytes,
-        "The bytes written to disk."
-    );
-    describe_gauge!(
-        "process_uptime_seconds",
-        Unit::Seconds,
-        "How much time the process has been running in seconds."
-    );
+
+    // describe_gauge!(
+    //     "process_cpu_usage_percentage",
+    //     Unit::Percent,
+    //     "The CPU percentage used."
+    // );
+    // describe_gauge!(
+    //     "process_virtual_memory_bytes",
+    //     Unit::Bytes,
+    //     "The virtual memory size in bytes."
+    // );
+    // describe_gauge!("process_memory_bytes", Unit::Bytes, "Memory size in bytes.");
+    // describe_gauge!(
+    //     "process_disk_total_written_bytes",
+    //     Unit::Bytes,
+    //     "The total bytes written to disk."
+    // );
+    // describe_gauge!(
+    //     "process_disk_written_bytes",
+    //     Unit::Bytes,
+    //     "The bytes written to disk."
+    // );
+    // describe_gauge!(
+    //     "process_disk_total_read_bytes",
+    //     Unit::Bytes,
+    //     "Total bytes Read from disk."
+    // );
+    // describe_gauge!(
+    //     "process_disk_read_bytes",
+    //     Unit::Bytes,
+    //     "The bytes read from disk."
+    // );
+    // describe_gauge!(
+    //     "process_disk_written_bytes",
+    //     Unit::Bytes,
+    //     "The bytes written to disk."
+    // );
+    // describe_gauge!(
+    //     "process_uptime_seconds",
+    //     Unit::Seconds,
+    //     "How much time the process has been running in seconds."
+    // );
 }
 
 /// Collect node metrics on a settings-defined interval.
 pub(crate) async fn collect_metrics(interval: u64) {
     let mut interval = tokio::time::interval(Duration::from_secs(interval));
 
+    // Log static system info
+    log_static_info();
+
     loop {
         interval.tick().await;
-        let sys_info = System::new();
-        if let Err(err) = get_stats(sys_info).await {
+        let sys_info = System::new_with_specifics(
+            RefreshKind::new()
+                .with_components()
+                .with_cpu(CpuRefreshKind::new().with_cpu_usage())
+                .with_memory()
+                .with_disks()
+                .with_processes(ProcessRefreshKind::everything().without_user()),
+        );
+        if let Err(err) = collect_stats(sys_info).await {
             warn!(
                 subject = "metrics.process_collection",
                 category = "metrics",
@@ -69,50 +112,123 @@ pub(crate) async fn collect_metrics(interval: u64) {
     }
 }
 
-async fn get_stats(mut sys: System) -> Result<()> {
-    let pid = get_current_pid().map_err(|e| anyhow!("no process pid found {}", e))?;
-
-    let is_process_refreshed = sys.refresh_process(pid);
-    sys.refresh_cpu();
-
-    if is_process_refreshed {
-        let proc = sys.process(pid).context("no process associated with pid")?;
-        let cpus = num_cpus::get();
-        let disk = proc.disk_usage();
-
-        // cpu-usage divided by # of cores.
-        metrics::gauge!(
-            "process_cpu_usage_percentage",
-            f64::from(sys.global_cpu_info().cpu_usage() / (cpus as f32))
-        );
-
-        // The docs for sysinfo indicate that `virtual_memory`
-        // returns in KB, but that is incorrect.
-        // See this issue: https://github.com/GuillaumeGomez/sysinfo/issues/428#issuecomment-774098021
-        // And this PR: https://github.com/GuillaumeGomez/sysinfo/pull/430/files
-        metrics::gauge!(
-            "process_virtual_memory_bytes",
-            (proc.virtual_memory()) as f64
-        );
-        metrics::gauge!("process_memory_bytes", (proc.memory() * 1_000) as f64);
-        metrics::gauge!("process_uptime_seconds", proc.run_time() as f64);
-        metrics::gauge!(
-            "process_disk_total_written_bytes",
-            disk.total_written_bytes as f64,
-        );
-        metrics::gauge!("process_disk_written_bytes", disk.written_bytes as f64);
-        metrics::gauge!(
-            "process_disk_total_read_bytes",
-            disk.total_read_bytes as f64,
-        );
-        metrics::gauge!("process_disk_read_bytes", disk.read_bytes as f64);
-    } else {
-        info!(
-            subject = "metrics.process_collection",
-            category = "metrics",
-            "failed to refresh process information, metrics may show old results"
-        );
+async fn collect_stats(sys: System) -> Result<()> {
+    fn compute_available_disk_space(disks: &[Disk]) -> u64 {
+        disks
+            .iter()
+            .fold(0, |acc, disk| acc + disk.available_space())
     }
 
+    // System metrics
+    metrics::gauge!("system_available_memory", sys.available_memory() as f64);
+    metrics::gauge!("system_used_memory", sys.used_memory() as f64);
+    metrics::gauge!("system_free_swap", sys.free_swap() as f64);
+    metrics::gauge!("system_used_swap", sys.used_swap() as f64);
+    metrics::gauge!(
+        "system_disk_available_space",
+        compute_available_disk_space(sys.disks()) as f64
+    );
+    metrics::gauge!("system_uptime", sys.uptime() as f64);
+    metrics::gauge!("system_load_average", sys.load_average().five);
+
+    // Process metrics
+    // let pid = get_current_pid().map_err(|e| anyhow!("no process pid found {}", e))?;
+
+    // let is_process_refreshed = sys.refresh_process(pid);
+    // sys.refresh_cpu();
+
+    // if is_process_refreshed {
+    //     let proc = sys.process(pid).context("no process associated with pid")?;
+    //     let cpus = num_cpus::get();
+    //     let disk = proc.disk_usage();
+
+    //     // cpu-usage divided by # of cores.
+    //     metrics::gauge!(
+    //         "process_cpu_usage_percentage",
+    //         f64::from(sys.global_cpu_info().cpu_usage() / (cpus as f32))
+    //     );
+
+    // The docs for sysinfo indicate that `virtual_memory`
+    // returns in KB, but that is incorrect.
+    // See this issue: https://github.com/GuillaumeGomez/sysinfo/issues/428#issuecomment-774098021
+    // And this PR: https://github.com/GuillaumeGomez/sysinfo/pull/430/files
+    //     metrics::gauge!(
+    //         "process_virtual_memory_bytes",
+    //         (proc.virtual_memory()) as f64
+    //     );
+    //     metrics::gauge!("process_memory_bytes", (proc.memory() * 1_000) as f64);
+    //     metrics::gauge!("process_uptime_seconds", proc.run_time() as f64);
+    //     metrics::gauge!(
+    //         "process_disk_total_written_bytes",
+    //         disk.total_written_bytes as f64,
+    //     );
+    //     metrics::gauge!("process_disk_written_bytes", disk.written_bytes as f64);
+    //     metrics::gauge!(
+    //         "process_disk_total_read_bytes",
+    //         disk.total_read_bytes as f64,
+    //     );
+    //     metrics::gauge!("process_disk_read_bytes", disk.read_bytes as f64);
+    // } else {
+    //     info!(
+    //         subject = "metrics.process_collection",
+    //         category = "metrics",
+    //         "failed to refresh process information, metrics may show old results"
+    //     );
+    // }
+
     Ok(())
+}
+
+// Log static system information
+fn log_static_info() {
+    fn compute_total_disk_space(disks: &[Disk]) -> u64 {
+        disks.iter().fold(0, |acc, disk| acc + disk.total_space())
+    }
+
+    let sys = System::new_with_specifics(
+        RefreshKind::new()
+            .with_components()
+            .with_cpu(CpuRefreshKind::new())
+            .with_memory()
+            .with_disks(),
+    );
+
+    info!(
+        subject = "metrics",
+        category = "homestar_runtime",
+        "Running on {} at kernel version {}",
+        sys.long_os_version().unwrap_or(String::from("Unknown")),
+        sys.kernel_version().unwrap_or(String::from("Unknown")),
+    );
+    info!(
+        subject = "metrics",
+        category = "homestar_runtime",
+        "System booted at UNIX time {}",
+        sys.boot_time(),
+    );
+    info!(
+        subject = "metrics",
+        category = "homestar_runtime",
+        "Physical core count of all the CPUs: {}",
+        sys.physical_core_count().unwrap_or(0),
+    );
+    info!(
+        subject = "metrics",
+        category = "homestar_runtime",
+        "Total memory on machine: {}",
+        sys.total_memory(),
+    );
+    info!(
+        subject = "metrics",
+        category = "homestar_runtime",
+        "Total swap on machine: {}",
+        sys.total_swap(),
+    );
+
+    info!(
+        subject = "metrics",
+        category = "homestar_runtime",
+        "Total disk space on machine: {}",
+        compute_total_disk_space(sys.disks()) as f64
+    );
 }

--- a/homestar-runtime/src/metrics/node.rs
+++ b/homestar-runtime/src/metrics/node.rs
@@ -110,7 +110,7 @@ pub(crate) fn describe() {
 
 /// Collect node metrics on a settings-defined interval.
 pub(crate) async fn collect_metrics(interval: u64) {
-    let mut interval = tokio::time::interval(Duration::from_secs(interval));
+    let mut interval = tokio::time::interval(Duration::from_millis(interval));
 
     // Log static system info
     log_static_info();

--- a/homestar-runtime/src/runner.rs
+++ b/homestar-runtime/src/runner.rs
@@ -9,6 +9,7 @@ use crate::{
     channel::{AsyncBoundedChannel, AsyncBoundedChannelReceiver, AsyncBoundedChannelSender},
     db::Database,
     event_handler::{Event, EventHandler},
+    metrics,
     network::{rpc, swarm},
     worker::WorkerMessage,
     workflow, Settings, Worker,
@@ -258,6 +259,10 @@ impl Runner {
         let (rpc_tx, mut rpc_rx) = Self::setup_rpc_channel(message_buffer_len);
         let (runner_worker_tx, mut runner_worker_rx) =
             Self::setup_worker_channel(message_buffer_len);
+
+        #[cfg(feature = "metrics")]
+        self.runtime
+            .block_on(metrics::start(&self.settings.monitoring))?;
 
         let shutdown_timeout = self.settings.node.shutdown_timeout;
         let rpc_server = rpc::Server::new(self.settings.node.network(), rpc_tx.into());

--- a/homestar-runtime/src/settings.rs
+++ b/homestar-runtime/src/settings.rs
@@ -37,7 +37,6 @@ impl Settings {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Monitoring {
     /// Monitoring collection interval in milliseconds.
-    #[allow(dead_code)]
     pub process_collector_interval: u64,
     /// Metrics port for prometheus scraping.
     pub metrics_port: u16,

--- a/homestar-runtime/src/settings.rs
+++ b/homestar-runtime/src/settings.rs
@@ -38,7 +38,9 @@ impl Settings {
 pub struct Monitoring {
     /// Monitoring collection interval.
     #[allow(dead_code)]
-    process_collector_interval: u64,
+    pub process_collector_interval: u64,
+    /// Metrics port for prometheus scraping.
+    pub metrics_port: u16,
 }
 
 /// Server settings.
@@ -156,6 +158,7 @@ pub(crate) struct Database {
 impl Default for Monitoring {
     fn default() -> Self {
         Self {
+            metrics_port: 4000,
             process_collector_interval: 10,
         }
     }

--- a/homestar-runtime/src/settings.rs
+++ b/homestar-runtime/src/settings.rs
@@ -36,7 +36,7 @@ impl Settings {
 /// Process monitoring settings.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Monitoring {
-    /// Monitoring collection interval.
+    /// Monitoring collection interval in milliseconds.
     #[allow(dead_code)]
     pub process_collector_interval: u64,
     /// Metrics port for prometheus scraping.
@@ -159,7 +159,7 @@ impl Default for Monitoring {
     fn default() -> Self {
         Self {
             metrics_port: 4000,
-            process_collector_interval: 10,
+            process_collector_interval: 5000,
         }
     }
 }

--- a/homestar-runtime/tests/lib.rs
+++ b/homestar-runtime/tests/lib.rs
@@ -1,0 +1,3 @@
+pub(crate) mod cli;
+pub(crate) mod metrics;
+pub(crate) mod utils;

--- a/homestar-runtime/tests/metrics.rs
+++ b/homestar-runtime/tests/metrics.rs
@@ -1,0 +1,70 @@
+use crate::utils::{kill_homestar_process, stop_homestar};
+use anyhow::Result;
+use assert_cmd::crate_name;
+#[cfg(not(windows))]
+use once_cell::sync::Lazy;
+use reqwest::StatusCode;
+use retry::{delay::Fixed, retry, OperationResult};
+use serial_test::file_serial;
+use std::{
+    path::PathBuf,
+    process::{Command, Stdio},
+    thread, time,
+};
+
+static BIN: Lazy<PathBuf> = Lazy::new(|| assert_cmd::cargo::cargo_bin(crate_name!()));
+const METRICS_URL: &str = "http://localhost:4000";
+
+#[test]
+#[file_serial]
+fn test_metrics_serial() -> Result<()> {
+    fn sample_metrics() -> prometheus_parse::Value {
+        let body = retry(
+            Fixed::from_millis(500).take(2),
+            || match reqwest::blocking::get(METRICS_URL) {
+                Ok(response) => match response.status() {
+                    StatusCode::OK => OperationResult::Ok(response.text()),
+                    _ => OperationResult::Err("Metrics server failed to serve metrics"),
+                },
+                Err(_) => OperationResult::Retry("Metrics server not available"),
+            },
+        )
+        .unwrap()
+        .expect("Metrics server failed to serve metrics");
+
+        let lines: Vec<_> = body.lines().map(|s| Ok(s.to_owned())).collect();
+        let metrics =
+            prometheus_parse::Scrape::parse(lines.into_iter()).expect("Unable to parse metrics");
+
+        metrics
+            .samples
+            .iter()
+            .find(|sample| sample.metric.as_str() == "system_used_memory_bytes")
+            .expect("Could not find system_used_memory_bytes metric")
+            .value
+            .to_owned()
+    }
+
+    let _ = stop_homestar();
+
+    Command::new(BIN.as_os_str())
+        .arg("start")
+        .arg("-c")
+        .arg("tests/test_node2/config/settings.toml")
+        .arg("--db")
+        .arg("homestar.db")
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let sample1 = sample_metrics();
+    thread::sleep(time::Duration::from_millis(600));
+    let sample2 = sample_metrics();
+
+    assert_ne!(sample1, sample2);
+
+    let _ = stop_homestar();
+    let _ = kill_homestar_process();
+
+    Ok(())
+}

--- a/homestar-runtime/tests/test_node1/config/settings.toml
+++ b/homestar-runtime/tests/test_node1/config/settings.toml
@@ -1,5 +1,6 @@
 [monitoring]
-process_collector_interval = 10
+process_collector_interval = 500
+metrics_port = 4000
 
 [node]
 

--- a/homestar-runtime/tests/test_node2/config/settings.toml
+++ b/homestar-runtime/tests/test_node2/config/settings.toml
@@ -7,5 +7,5 @@ process_collector_interval = 10
 rpc_port = 3032
 websocket_port = 9092
 node_addresses = [
-    "/ip4/127.0.0.1/tcp/9091/ws/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN"
+  "/ip4/127.0.0.1/tcp/9091/ws/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN",
 ]

--- a/homestar-runtime/tests/test_node2/config/settings.toml
+++ b/homestar-runtime/tests/test_node2/config/settings.toml
@@ -1,5 +1,6 @@
 [monitoring]
-process_collector_interval = 10
+process_collector_interval = 500
+metrics_port = 4000
 
 [node]
 

--- a/homestar-runtime/tests/utils.rs
+++ b/homestar-runtime/tests/utils.rs
@@ -1,0 +1,120 @@
+use anyhow::{Context, Result};
+use assert_cmd::{crate_name, prelude::*};
+#[cfg(not(windows))]
+use nix::{
+    sys::signal::{self, Signal},
+    unistd::Pid,
+};
+use once_cell::sync::Lazy;
+use retry::{delay::Fixed, retry};
+use std::{
+    net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpStream},
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+use sysinfo::{PidExt, ProcessExt, SystemExt};
+
+static BIN: Lazy<PathBuf> = Lazy::new(|| assert_cmd::cargo::cargo_bin(crate_name!()));
+const IPFS: &str = "ipfs";
+
+pub(crate) fn startup_ipfs() -> Result<()> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".ipfs");
+    println!("starting ipfs daemon...{}", path.to_str().unwrap());
+    let mut ipfs_daemon = Command::new(IPFS)
+        .args([
+            "--repo-dir",
+            path.to_str().unwrap(),
+            "--offline",
+            "daemon",
+            "--init",
+        ])
+        .stdout(Stdio::piped())
+        .spawn()?;
+
+    // wait for ipfs daemon to start by testing for a connection
+    let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5001);
+    let result = retry(Fixed::from_millis(500), || {
+        TcpStream::connect(socket).map(|stream| stream.shutdown(Shutdown::Both))
+    });
+
+    if let Err(err) = result {
+        ipfs_daemon.kill().unwrap();
+        panic!("`ipfs daemon` failed to start: {:?}", err);
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn stop_homestar() -> Result<()> {
+    Command::new(BIN.as_os_str())
+        .arg("stop")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("failed to stop Homestar server")?;
+
+    Ok(())
+}
+
+pub(crate) fn stop_ipfs() -> Result<()> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".ipfs");
+    Command::new(IPFS)
+        .args(["--repo-dir", path.to_str().unwrap(), "shutdown"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("failed to stop IPFS daemon")?;
+
+    Ok(())
+}
+
+pub(crate) fn stop_all_bins() -> Result<()> {
+    let _ = stop_ipfs();
+    let _ = stop_homestar();
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+pub(crate) fn kill_homestar_process() -> Result<()> {
+    let system = sysinfo::System::new_all();
+    let pid = system
+        .processes_by_exact_name("homestar-runtime")
+        .collect::<Vec<_>>()
+        .first()
+        .map(|p| p.pid().as_u32())
+        .unwrap_or(
+            std::fs::read_to_string("/tmp/homestar.pid")
+                .expect("Should have a PID file")
+                .trim()
+                .parse::<u32>()
+                .unwrap(),
+        );
+
+    let _result = signal::kill(Pid::from_raw(pid.try_into().unwrap()), Signal::SIGTERM);
+    let _result = retry(Fixed::from_millis(500), || {
+        Command::new(BIN.as_os_str())
+            .arg("ping")
+            .assert()
+            .try_failure()
+    });
+
+    Ok(())
+}
+
+#[cfg(windows)]
+pub(crate) fn kill_homestar_process() -> Result<()> {
+    let system = sysinfo::System::new_all();
+    let pid = system
+        .processes_by_exact_name("homestar-runtime.exe")
+        .collect::<Vec<_>>()
+        .first()
+        .map(|x| x.pid())
+        .unwrap();
+
+    if let Some(process) = system.process(pid) {
+        process.kill();
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

This PR adds the following features:

- [x] Add system metrics
- [x] Add process metrics
- [x] Add network metrics
- [x] Add load average metric
- [x] Add database size metric
- [x] Add OS and kernel log entry
- [x] Add Prometheus exporter with endpoint for scraping
- [x] Move integration test utils into a separate module
- [x] Break Homestar process kills into *nix and windows functions
- [x] Switch from `serial` to `file_serial` in integration tests
- [x] Add `taplo` to pre-commit config and nix flake 

## Link to issue

Implements #184

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor

## Test plan (required)

We have an integration test in `homestar-runtime/tests/metrics.rs`.
