### PR TITLE
feat: Add mDNS and Rendezvous configs

### DIFF
--- a/homestar-runtime/src/event_handler/swarm_event.rs
+++ b/homestar-runtime/src/event_handler/swarm_event.rs
@@ -549,7 +549,10 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
 
             if let Some(mdns) = behaviour.mdns.as_ref() {
                 for (peer_id, multiaddr) in list {
-                    info!("mDNS discover peer has expired: {peer_id}");
+                    info!(
+                        peer_id = peer_id.to_string(),
+                        "mDNS discover peer has expired"
+                    );
                     if mdns.has_node(&peer_id) {
                         behaviour.kademlia.remove_address(&peer_id, &multiaddr);
                     }

--- a/homestar-runtime/src/settings.rs
+++ b/homestar-runtime/src/settings.rs
@@ -80,12 +80,12 @@ pub struct Network {
     pub(crate) enable_rendezvous: bool,
     /// Enable mDNS.
     pub(crate) enable_mdns: bool,
-    /// MDNS IPv6 enable flag
+    /// mDNS IPv6 enable flag
     pub(crate) mdns_enable_ipv6: bool,
-    /// MDNS query interval.
+    /// mDNS query interval.
     #[serde_as(as = "DurationSeconds<u64>")]
     pub(crate) mdns_query_interval: Duration,
-    /// MDNS TTL.
+    /// mDNS TTL.
     #[serde_as(as = "DurationSeconds<u64>")]
     pub(crate) mdns_ttl: Duration,
     /// Timeout for p2p requests for a provided record.

--- a/homestar-runtime/src/settings.rs
+++ b/homestar-runtime/src/settings.rs
@@ -76,12 +76,16 @@ pub struct Network {
     /// [Swarm]: libp2p::swarm::Swarm
     #[serde(with = "http_serde::uri")]
     pub(crate) listen_address: Uri,
-    /// Mdns IPv6 enable flag.
+    /// Enable Rendezvous protocol.
+    pub(crate) enable_rendezvous: bool,
+    /// Enable mDNS.
+    pub(crate) enable_mdns: bool,
+    /// MDNS IPv6 enable flag
     pub(crate) mdns_enable_ipv6: bool,
-    /// Mdns query interval.
+    /// MDNS query interval.
     #[serde_as(as = "DurationSeconds<u64>")]
     pub(crate) mdns_query_interval: Duration,
-    /// Mdns TTL.
+    /// MDNS TTL.
     #[serde_as(as = "DurationSeconds<u64>")]
     pub(crate) mdns_ttl: Duration,
     /// Timeout for p2p requests for a provided record.
@@ -181,6 +185,8 @@ impl Default for Network {
             events_buffer_len: 1024,
             listen_address: Uri::from_static("/ip4/0.0.0.0/tcp/0"),
             // TODO: we would like to enable this by default, however this breaks mdns on at least some linux distros. Requires further investigation.
+            enable_rendezvous: true,
+            enable_mdns: true,
             mdns_enable_ipv6: false,
             mdns_query_interval: Duration::from_secs(5 * 60),
             mdns_ttl: Duration::from_secs(60 * 9),

--- a/homestar-runtime/tests/fixtures/test_mdns_connect1.toml
+++ b/homestar-runtime/tests/fixtures/test_mdns_connect1.toml
@@ -9,6 +9,7 @@ console_subscriber_port = 5560
 rpc_port = 9800
 websocket_port = 8000
 listen_address = "/ip4/0.0.0.0/tcp/0"
+enable_rendezvous = false
 
 [node.network.keypair_config]
 existing = { key_type = "ed25519", path = "./fixtures/__testkey_ed25519.pem" }

--- a/homestar-runtime/tests/fixtures/test_mdns_connect2.toml
+++ b/homestar-runtime/tests/fixtures/test_mdns_connect2.toml
@@ -9,6 +9,7 @@ console_subscriber_port = 5561
 rpc_port = 9801
 websocket_port = 8001
 listen_address = "/ip4/0.0.0.0/tcp/0"
+enable_rendezvous = false
 
 [node.network.keypair_config]
 existing = { key_type = "secp256k1", path = "./fixtures/__testkey_secp256k1.der" }

--- a/homestar-runtime/tests/fixtures/test_network1.toml
+++ b/homestar-runtime/tests/fixtures/test_network1.toml
@@ -12,6 +12,8 @@ listen_address = "/ip4/127.0.0.1/tcp/7000"
 node_addresses = [
   "/ip4/127.0.0.1/tcp/7001/p2p/16Uiu2HAm3g9AomQNeEctL2hPwLapap7AtPSNt8ZrBny4rLx1W5Dc",
 ]
+enable_mdns = false
+enable_rendezvous = false
 
 [node.network.keypair_config]
 existing = { key_type = "ed25519", path = "./fixtures/__testkey_ed25519.pem" }

--- a/homestar-runtime/tests/fixtures/test_network2.toml
+++ b/homestar-runtime/tests/fixtures/test_network2.toml
@@ -12,6 +12,8 @@ listen_address = "/ip4/127.0.0.1/tcp/7001"
 node_addresses = [
   "/ip4/127.0.0.1/tcp/7000/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN",
 ]
+enable_mdns = false
+enable_rendezvous = false
 
 [node.network.keypair_config]
 existing = { key_type = "secp256k1", path = "./fixtures/__testkey_secp256k1.der" }


### PR DESCRIPTION
# Description

This PR implements the following features:

- [x] Add `enable_mdns` config
- [x] Add `enable_rendezvous` config

These configs determine whether we toggle mDNS and Rendezvous on or off. In addition, we check the toggle states in event handlers where we might use mDNS or Rendezvous.

## Link to issue

Closes #376 

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

All existing tests should pass. In particular, we are interested in the multi-node tests that rely on known peers and mDNS.

