### PR TITLE
remove `*.png` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ private
 *.db-shm
 *.db-wal
 *.tmp
-*.png
 *.dot
 .history
 .DS_Store


### PR DESCRIPTION
There are committed `png` files, so we don't want to ignore all of them, right? 🤔 

Having files gitignored and committed confuses [release-plz](https://github.com/MarcoIeni/release-plz-action/issues/89). Is this a common pattern?
Usually I don't gitignore things I commit.

Committed png files: `["assets/a_logo.png", "examples/websocket-relay/synthcat.png"]`.


## Alternative

Remove the committed `.png`.