### PR TITLE
chore: add a nix package

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,10 +2,10 @@ name: 📦 Nix Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
   pull_request:
-    branches: [ '**' ]
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -55,3 +55,4 @@ jobs:
         run: |
           nix develop --show-trace -c irust --version
           nix develop --show-trace -c rustc --version
+          nix build . && ./result/bin/homestar --version

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ examples/**/tmp/*
 
 !examples/**/**/.env.example
 !examples/**/tmp/.gitkeep
+
+# nix build results
+/result

--- a/examples/websocket-relay/README.md
+++ b/examples/websocket-relay/README.md
@@ -6,7 +6,7 @@ An example application that connects to a `homestar-runtime` node
 over a websocket connection in order to run static Wasm-based, image
 processing workflows that chain inputs and outputs using
 [inlined promises][pipelines].
- 
+
 This application demonstrates:
 
   * websocket notifications of [UCAN Invocation Receipts][spec-receipts] sent

--- a/flake.nix
+++ b/flake.nix
@@ -234,8 +234,7 @@
           wasmTest
           wasmAdd
         ];
-      in rec
-      {
+      in {
         devShells.default = pkgs.mkShell {
           name = "homestar";
           nativeBuildInputs = with pkgs;
@@ -296,6 +295,25 @@
           doCheck = false;
           cargoSha256 = "sha256-FmsD3ajMqpPrTkXCX2anC+cmm0a2xuP+3FHqzj56Ma4=";
         };
+
+        packages.default =
+          pkgs.rustPlatform.buildRustPackage
+          {
+            name = "homestar";
+            src = ./.;
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+            buildInputs = with pkgs;
+              [rust-toolchain]
+              ++ lib.optionals stdenv.isDarwin [
+                darwin.apple_sdk.frameworks.Security
+                darwin.apple_sdk.frameworks.CoreFoundation
+                darwin.apple_sdk.frameworks.Foundation
+              ];
+
+            doCheck = false;
+          };
 
         formatter = pkgs.alejandra;
       }


### PR DESCRIPTION
# Description

Adding a default package definition to the flake (and also tests the build in CI)

## Link to issue

Related to https://github.com/ipvm-wg/homestar/issues/362

## Type of change

- [x] New feature (non-breaking change that adds functionality)

Please delete options that are not relevant.

## Test plan (required)

The `nix` workflow will now build the default homestar package
