### PR TITLE
feat: Add pubsub receipt sharing notifications

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,7 +9,7 @@ failure-output = "immediate-final"
 fail-fast = false
 
 [test-groups]
-serial = { max-threads = 1, threads-required = 1 }
+serial = { max-threads = 1 }
 
 [[profile.default.overrides]]
 filter = 'test(/_serial$/)'
@@ -18,3 +18,7 @@ test-group = 'serial'
 [[profile.ci.overrides]]
 filter = 'test(/_serial$/)'
 test-group = 'serial'
+
+[[profile.ci.overrides]]
+platform = 'cfg(target_os = "window")'
+retries = { count = 8, delay = "60s", jitter = true, max-delay = "500s" }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,12 +4,12 @@ test-threads = "num-cpus"
 threads-required = 1
 
 [profile.ci]
-retries = { backoff = "exponential", count = 3, delay = "5s", jitter = true, max-delay = "30s" }
+retries = { backoff = "exponential", count = 5, delay = "5s", jitter = true, max-delay = "30s" }
 failure-output = "immediate-final"
 fail-fast = false
 
 [test-groups]
-serial = { max-threads = 1 }
+serial = { max-threads = 1, threads-required = 1 }
 
 [[profile.default.overrides]]
 filter = 'test(/_serial$/)'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,7 +4,7 @@ test-threads = "num-cpus"
 threads-required = 1
 
 [profile.ci]
-retries = { backoff = "exponential", count = 5, delay = "5s", jitter = true, max-delay = "30s" }
+retries = { backoff = "exponential", count = 3, delay = "5s", jitter = true, max-delay = "30s" }
 failure-output = "immediate-final"
 fail-fast = false
 
@@ -16,9 +16,10 @@ filter = 'test(/_serial$/)'
 test-group = 'serial'
 
 [[profile.ci.overrides]]
+platform = { host = 'cfg(windows)' }
+retries = { backoff = "exponential", count = 3, delay = "45s", jitter = true, max-delay = "500s" }
+slow-timeout = { period = "120s", terminate-after = 2 }
+
+[[profile.ci-windows.overrides]]
 filter = 'test(/_serial$/)'
 test-group = 'serial'
-
-[[profile.ci.overrides]]
-platform = 'cfg(target_os = "window")'
-retries = { count = 8, delay = "60s", jitter = true, max-delay = "500s" }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,6 +6,7 @@ threads-required = 1
 [profile.ci]
 retries = { backoff = "exponential", count = 3, delay = "5s", jitter = true, max-delay = "30s" }
 failure-output = "immediate-final"
+leak-timeout = "800ms"
 fail-fast = false
 
 [test-groups]
@@ -16,11 +17,12 @@ filter = 'test(/_serial$/)'
 test-group = 'serial'
 
 [[profile.ci.overrides]]
-platform = { host = 'cfg(windows)' }
+platform = { host = 'cfg(target_os = "windows")' }
+filter = 'test(/_serial$/)'
+test-group = 'serial'
 retries = { backoff = "exponential", count = 5, delay = "60s", jitter = true, max-delay = "500s" }
 slow-timeout = { period = "120s", terminate-after = 2 }
-fail-fast = true
 
-[[profile.ci-windows.overrides]]
+[[profile.ci.overrides]]
 filter = 'test(/_serial$/)'
 test-group = 'serial'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,8 +17,9 @@ test-group = 'serial'
 
 [[profile.ci.overrides]]
 platform = { host = 'cfg(windows)' }
-retries = { backoff = "exponential", count = 3, delay = "45s", jitter = true, max-delay = "500s" }
+retries = { backoff = "exponential", count = 5, delay = "60s", jitter = true, max-delay = "500s" }
 slow-timeout = { period = "120s", terminate-after = 2 }
+fail-fast = true
 
 [[profile.ci-windows.overrides]]
 filter = 'test(/_serial$/)'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,9 +4,10 @@ test-threads = "num-cpus"
 threads-required = 1
 
 [profile.ci]
-retries = { backoff = "exponential", count = 3, delay = "5s", jitter = true, max-delay = "30s" }
+retries = { backoff = "exponential", count = 3, delay = "30s", jitter = true, max-delay = "300s" }
 failure-output = "immediate-final"
 leak-timeout = "800ms"
+slow-timeout = { period = "120s", terminate-after = 2 }
 fail-fast = false
 
 [test-groups]
@@ -15,13 +16,6 @@ serial = { max-threads = 1 }
 [[profile.default.overrides]]
 filter = 'test(/_serial$/)'
 test-group = 'serial'
-
-[[profile.ci.overrides]]
-platform = { host = 'cfg(target_os = "windows")' }
-filter = 'test(/_serial$/)'
-test-group = 'serial'
-retries = { backoff = "exponential", count = 5, delay = "60s", jitter = true, max-delay = "500s" }
-slow-timeout = { period = "120s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
 filter = 'test(/_serial$/)'

--- a/.github/workflows/tests_and_checks.yml
+++ b/.github/workflows/tests_and_checks.yml
@@ -236,7 +236,7 @@ jobs:
 
       - name: Run Tests (all-features)
         if: ${{ matrix.default-features == 'all' }}
-        run: cargo nextest run --workspace --profile ci --all-features --no-capture
+        run: cargo nextest run --workspace --profile ci --all-features
         continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
 
       - name: Run Tests (no-default-features)
@@ -246,7 +246,6 @@ jobs:
       - name: Run Doc Tests
         if: ${{ matrix.default-features == 'all' }}
         run: cargo test --doc --workspace
-        continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
 
   run-docs:
     needs: changes

--- a/.github/workflows/tests_and_checks.yml
+++ b/.github/workflows/tests_and_checks.yml
@@ -236,12 +236,12 @@ jobs:
 
       - name: Run Tests (all-features)
         if: ${{ matrix.default-features == 'all' }}
-        run: cargo nextest run --workspace --profile ci --all-features
+        run: cargo nextest run --workspace --profile ci-windows --all-features
         continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
 
       - name: Run Tests (no-default-features)
         if: ${{ matrix.default-features == 'none' }}
-        run: cargo nextest run --profile ci --no-default-features --features "test-utils"
+        run: cargo nextest run --profile ci-windows --no-default-features --features "test-utils"
 
       - name: Run Doc Tests
         if: ${{ matrix.default-features == 'all' }}

--- a/.github/workflows/tests_and_checks.yml
+++ b/.github/workflows/tests_and_checks.yml
@@ -236,12 +236,12 @@ jobs:
 
       - name: Run Tests (all-features)
         if: ${{ matrix.default-features == 'all' }}
-        run: cargo nextest run --workspace --profile ci-windows --all-features
+        run: cargo nextest run --workspace --profile ci --all-features
         continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
 
       - name: Run Tests (no-default-features)
         if: ${{ matrix.default-features == 'none' }}
-        run: cargo nextest run --profile ci-windows --no-default-features --features "test-utils"
+        run: cargo nextest run --profile ci --no-default-features --features "test-utils"
 
       - name: Run Doc Tests
         if: ${{ matrix.default-features == 'all' }}

--- a/.github/workflows/tests_and_checks.yml
+++ b/.github/workflows/tests_and_checks.yml
@@ -236,7 +236,7 @@ jobs:
 
       - name: Run Tests (all-features)
         if: ${{ matrix.default-features == 'all' }}
-        run: cargo nextest run --workspace --profile ci --all-features
+        run: cargo nextest run --workspace --profile ci --all-features --no-capture
         continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
 
       - name: Run Tests (no-default-features)

--- a/.ignore
+++ b/.ignore
@@ -17,6 +17,8 @@ LICENSE
 .pre-commit-config.yaml
 
 **/fixtures
+*.ipfs*
+*.db
 
 ## examples
 examples/websocket-relay/relay-app

--- a/homestar-core/src/test_utils/workflow.rs
+++ b/homestar-core/src/test_utils/workflow.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use url::Url;
 
 const RAW: u64 = 0x55;
-const WASM_CID: &str = "bafkreihxcyjgyrz437ewzi7md55uqt2zf6yr3zn7xrfi4orc34xdc5jgrm";
+const WASM_CID: &str = "bafybeiczefaiu7464ehupezpzulnti5jvcwnvdalqrdliugnnwcdz6ljia";
 
 type NonceBytes = Vec<u8>;
 

--- a/homestar-core/src/workflow/instruction.rs
+++ b/homestar-core/src/workflow/instruction.rs
@@ -330,7 +330,7 @@ mod test {
                 (
                     RESOURCE_KEY.into(),
                     Ipld::String(
-                        "ipfs://bafkreihxcyjgyrz437ewzi7md55uqt2zf6yr3zn7xrfi4orc34xdc5jgrm".into()
+                        "ipfs://bafybeiczefaiu7464ehupezpzulnti5jvcwnvdalqrdliugnnwcdz6ljia".into()
                     )
                 ),
                 (OP_KEY.into(), Ipld::String("ipld/fun".to_string())),

--- a/homestar-core/src/workflow/pointer.rs
+++ b/homestar-core/src/workflow/pointer.rs
@@ -18,11 +18,7 @@ use diesel::{
     AsExpression, FromSqlRow,
 };
 use enum_assoc::Assoc;
-use libipld::{
-    cid::{multibase::Base, Cid},
-    serde::from_ipld,
-    Ipld, Link,
-};
+use libipld::{cid::Cid, serde::from_ipld, Ipld, Link};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::btree_map::BTreeMap, fmt, str::FromStr};
 
@@ -183,11 +179,7 @@ pub struct Pointer(Cid);
 
 impl fmt::Display for Pointer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let cid_as_string = self
-            .0
-            .to_string_of_base(Base::Base32Lower)
-            .map_err(|_| fmt::Error)?;
-
+        let cid_as_string = self.0.to_string();
         write!(f, "{cid_as_string}")
     }
 }

--- a/homestar-core/src/workflow/task.rs
+++ b/homestar-core/src/workflow/task.rs
@@ -190,7 +190,7 @@ mod test {
             (
                 "rsc".into(),
                 Ipld::String(
-                    "ipfs://bafkreihxcyjgyrz437ewzi7md55uqt2zf6yr3zn7xrfi4orc34xdc5jgrm".into(),
+                    "ipfs://bafybeiczefaiu7464ehupezpzulnti5jvcwnvdalqrdliugnnwcdz6ljia".into(),
                 ),
             ),
             ("op".into(), Ipld::String("ipld/fun".to_string())),

--- a/homestar-runtime/Cargo.toml
+++ b/homestar-runtime/Cargo.toml
@@ -32,6 +32,7 @@ bench = false
 [[test]]
 name = "integration"
 path = "tests/main.rs"
+required-features = ["test-utils"]
 
 [dependencies]
 # return to version.workspace = true after the following issue is fixed:

--- a/homestar-runtime/src/event_handler/event.rs
+++ b/homestar-runtime/src/event_handler/event.rs
@@ -2,15 +2,14 @@
 
 use super::EventHandler;
 #[cfg(feature = "websocket-notify")]
-use crate::event_handler::notification::emit_receipt;
+use crate::event_handler::notification::{
+    self, emit_receipt, EventNotificationTyp, SwarmNotification,
+};
 #[cfg(feature = "ipfs")]
 use crate::network::IpfsCli;
 use crate::{
     db::Database,
-    event_handler::{
-        notification::{self, EventNotificationTyp, SwarmNotification},
-        Handler, P2PSender, ResponseEvent,
-    },
+    event_handler::{Handler, P2PSender, ResponseEvent},
     network::{
         pubsub,
         swarm::{CapsuleTag, RequestResponseKey, TopicMessage},
@@ -28,6 +27,7 @@ use libp2p::{
     rendezvous::Namespace,
     PeerId,
 };
+#[cfg(feature = "websocket-notify")]
 use maplit::btreemap;
 use std::{collections::HashSet, num::NonZeroUsize, sync::Arc};
 #[cfg(feature = "ipfs")]

--- a/homestar-runtime/src/event_handler/event.rs
+++ b/homestar-runtime/src/event_handler/event.rs
@@ -375,7 +375,9 @@ impl Replay {
                     )
                     .map(|msg_id|
                          info!(cid=receipt_cid,
-                               "message {msg_id} published on {} topic for receipt", pubsub::RECEIPTS_TOPIC))
+                             message_id = msg_id.to_string(),
+                             "message published on {} topic for receipt with cid: {receipt_cid}",
+                              pubsub::RECEIPTS_TOPIC))
                     .map_err(
                         |err|
                         warn!(err=?err, cid=receipt_cid,

--- a/homestar-runtime/src/event_handler/event.rs
+++ b/homestar-runtime/src/event_handler/event.rs
@@ -259,7 +259,8 @@ impl Captured {
             ) {
                 Ok(msg_id) => info!(
                     cid = receipt_cid.to_string(),
-                    "message {msg_id} published on {} topic for receipt",
+                    message_id = msg_id.to_string(),
+                    "message published on {} topic for receipt with cid: {receipt_cid}",
                     pubsub::RECEIPTS_TOPIC
                 ),
                 Err(err) => {

--- a/homestar-runtime/src/event_handler/event.rs
+++ b/homestar-runtime/src/event_handler/event.rs
@@ -9,7 +9,7 @@ use crate::event_handler::notification::{
 use crate::network::IpfsCli;
 use crate::{
     db::Database,
-    event_handler::{Handler, P2PSender, ResponseEvent},
+    event_handler::{channel::AsyncBoundedChannelSender, Handler, P2PSender, ResponseEvent},
     network::{
         pubsub,
         swarm::{CapsuleTag, RequestResponseKey, TopicMessage},
@@ -32,7 +32,6 @@ use maplit::btreemap;
 use std::{collections::HashSet, num::NonZeroUsize, sync::Arc};
 #[cfg(feature = "ipfs")]
 use tokio::runtime::Handle;
-use tokio::sync::oneshot;
 use tracing::{error, info, warn};
 
 /// A [Receipt] captured (inner) event.
@@ -96,7 +95,7 @@ pub(crate) enum Event {
     #[cfg(feature = "websocket-notify")]
     ReplayReceipts(Replay),
     /// General shutdown event.
-    Shutdown(oneshot::Sender<()>),
+    Shutdown(AsyncBoundedChannelSender<()>),
     /// Find a [Record] in the DHT, e.g. a [Receipt].
     ///
     /// [Record]: libp2p::kad::Record

--- a/homestar-runtime/src/event_handler/notification/swarm.rs
+++ b/homestar-runtime/src/event_handler/notification/swarm.rs
@@ -10,6 +10,8 @@ pub(crate) enum SwarmNotification {
     ListeningOn,
     OutgoingConnectionError,
     IncomingConnectionError,
+    PublishedReceiptPubsub,
+    ReceivedReceiptPubsub,
 }
 
 impl fmt::Display for SwarmNotification {
@@ -23,6 +25,12 @@ impl fmt::Display for SwarmNotification {
             }
             SwarmNotification::IncomingConnectionError => {
                 write!(f, "incomingConnectionError")
+            }
+            SwarmNotification::ReceivedReceiptPubsub => {
+                write!(f, "receivedReceiptPubsub")
+            }
+            SwarmNotification::PublishedReceiptPubsub => {
+                write!(f, "publishedReceiptPubsub")
             }
         }
     }
@@ -38,6 +46,8 @@ impl FromStr for SwarmNotification {
             "listeningOn" => Ok(Self::ListeningOn),
             "outgoingConnectionError" => Ok(Self::OutgoingConnectionError),
             "incomingConnectionError" => Ok(Self::IncomingConnectionError),
+            "receivedReceiptPubsub" => Ok(Self::ReceivedReceiptPubsub),
+            "publishedReceiptPubsub" => Ok(Self::PublishedReceiptPubsub),
             _ => Err(anyhow!("Missing swarm notification type: {}", ty)),
         }
     }

--- a/homestar-runtime/src/event_handler/swarm_event.rs
+++ b/homestar-runtime/src/event_handler/swarm_event.rs
@@ -406,7 +406,11 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
             } => match Receipt::try_from(message.data) {
                 // TODO: dont fail blindly if we get a non receipt message
                 Ok(receipt) => {
-                    info!("got message: {receipt} from {propagation_source} with message id: {message_id}");
+                    info!(
+                        peer_id = propagation_source.to_string(),
+                        message_id = message_id.to_string(),
+                        "message recevied on receipts topic: {receipt}"
+                    );
 
                     // Store gossiped receipt.
                     let _ = event_handler

--- a/homestar-runtime/src/event_handler/swarm_event.rs
+++ b/homestar-runtime/src/event_handler/swarm_event.rs
@@ -409,7 +409,7 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
                     info!(
                         peer_id = propagation_source.to_string(),
                         message_id = message_id.to_string(),
-                        "message recevied on receipts topic: {receipt}"
+                        "message received on receipts topic: {receipt}"
                     );
 
                     // Store gossiped receipt.

--- a/homestar-runtime/src/event_handler/swarm_event.rs
+++ b/homestar-runtime/src/event_handler/swarm_event.rs
@@ -745,7 +745,7 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
                 event_handler.ws_evt_sender(),
                 EventNotificationTyp::SwarmNotification(SwarmNotification::ListeningOn),
                 btreemap! {
-                    "peer_id" => local_peer.to_string(),
+                    "peerId" => local_peer.to_string(),
                     "address" => address.to_string()
                 },
             );
@@ -766,7 +766,7 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
                 event_handler.ws_evt_sender(),
                 EventNotificationTyp::SwarmNotification(SwarmNotification::ConnnectionEstablished),
                 btreemap! {
-                    "peer_id" => peer_id.to_string(),
+                    "peerId" => peer_id.to_string(),
                     "address" => endpoint.get_remote_address().to_string()
                 },
             );
@@ -811,7 +811,7 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
                 event_handler.ws_evt_sender(),
                 EventNotificationTyp::SwarmNotification(SwarmNotification::ConnnectionClosed),
                 btreemap! {
-                    "peer_id" => peer_id.to_string(),
+                    "peerId" => peer_id.to_string(),
                     "address" => endpoint.get_remote_address().to_string()
                 },
             );
@@ -833,7 +833,7 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
                 event_handler.ws_evt_sender(),
                 EventNotificationTyp::SwarmNotification(SwarmNotification::OutgoingConnectionError),
                 btreemap! {
-                    "peer_id" => peer_id.map_or("Unknown peer".into(), |p| p.to_string()),
+                    "peerId" => peer_id.map_or("Unknown peer".into(), |p| p.to_string()),
                     "error" => error.to_string()
                 },
             );

--- a/homestar-runtime/src/network/ipfs.rs
+++ b/homestar-runtime/src/network/ipfs.rs
@@ -78,8 +78,7 @@ impl IpfsCli {
         let DagPutResponse { cid } = self
             .0
             .dag_put_with_options(Cursor::new(receipt_bytes), dag_builder)
-            .await
-            .expect("a CID");
+            .await?;
 
         Ok(cid.cid_string)
     }

--- a/homestar-runtime/src/network/webserver.rs
+++ b/homestar-runtime/src/network/webserver.rs
@@ -254,7 +254,7 @@ mod test {
     use super::*;
     #[cfg(feature = "websocket-notify")]
     use crate::event_handler::notification::ReceiptNotification;
-    use crate::{db::Database, settings::Settings};
+    use crate::{channel::AsyncBoundedChannel, db::Database, settings::Settings};
     #[cfg(feature = "websocket-notify")]
     use homestar_core::{
         ipld::DagJson,
@@ -268,7 +268,6 @@ mod test {
     use jsonrpsee::{core::client::ClientT, rpc_params, ws_client::WsClientBuilder};
     #[cfg(feature = "websocket-notify")]
     use notifier::{self, Header};
-    use tokio::sync::mpsc;
 
     async fn metrics_handle(settings: Settings) -> PrometheusHandle {
         #[cfg(feature = "monitoring")]
@@ -290,7 +289,7 @@ mod test {
         runner.runtime.block_on(async {
             let server = Server::new(settings.node().network()).unwrap();
             let metrics_hdl = metrics_handle(settings).await;
-            let (runner_tx, _runner_rx) = mpsc::channel(1);
+            let (runner_tx, _runner_rx) = AsyncBoundedChannel::oneshot();
             server.start(runner_tx, metrics_hdl).await.unwrap();
 
             let ws_url = format!("ws://{}", server.addr);
@@ -332,7 +331,7 @@ mod test {
         runner.runtime.block_on(async {
             let server = Server::new(settings.node().network()).unwrap();
             let metrics_hdl = metrics_handle(settings).await;
-            let (runner_tx, _runner_rx) = mpsc::channel(1);
+            let (runner_tx, _runner_rx) = AsyncBoundedChannel::oneshot();
             server.start(runner_tx, metrics_hdl).await.unwrap();
 
             let ws_url = format!("ws://{}", server.addr);
@@ -365,7 +364,7 @@ mod test {
         runner.runtime.block_on(async {
             let server = Server::new(settings.node().network()).unwrap();
             let metrics_hdl = metrics_handle(settings).await;
-            let (runner_tx, _runner_rx) = mpsc::channel(1);
+            let (runner_tx, _runner_rx) = AsyncBoundedChannel::oneshot();
             server.start(runner_tx, metrics_hdl).await.unwrap();
 
             let ws_url = format!("ws://{}", server.addr);
@@ -442,7 +441,7 @@ mod test {
         runner.runtime.block_on(async {
             let server = Server::new(settings.node().network()).unwrap();
             let metrics_hdl = metrics_handle(settings).await;
-            let (runner_tx, _runner_rx) = mpsc::channel(1);
+            let (runner_tx, _runner_rx) = AsyncBoundedChannel::oneshot();
             server.start(runner_tx, metrics_hdl).await.unwrap();
 
             let ws_url = format!("ws://{}", server.addr);
@@ -476,7 +475,7 @@ mod test {
         runner.runtime.block_on(async {
             let server = Server::new(settings.node().network()).unwrap();
             let metrics_hdl = metrics_handle(settings).await;
-            let (runner_tx, _runner_rx) = mpsc::channel(1);
+            let (runner_tx, _runner_rx) = AsyncBoundedChannel::oneshot();
             server.start(runner_tx, metrics_hdl).await.unwrap();
 
             let ws_url = format!("ws://{}", server.addr);

--- a/homestar-runtime/src/settings.rs
+++ b/homestar-runtime/src/settings.rs
@@ -278,7 +278,7 @@ impl Default for Network {
             webserver_port: 1337,
             webserver_timeout: Duration::new(120, 0),
             websocket_capacity: 1024,
-            websocket_receiver_timeout: Duration::from_millis(1000),
+            websocket_receiver_timeout: Duration::from_millis(30_000),
             workflow_quorum: 3,
             keypair_config: PubkeyConfig::Random,
             node_addresses: Vec::new(),

--- a/homestar-runtime/src/tasks/fetch.rs
+++ b/homestar-runtime/src/tasks/fetch.rs
@@ -53,7 +53,7 @@ impl Fetch {
     }
 
     /// Gather resources via URLs, leveraging an exponential backoff.
-    #[cfg(all(not(feature = "ipfs"), not(test)))]
+    #[cfg(all(not(feature = "ipfs"), not(test), not(feature = "test-utils")))]
     #[allow(dead_code)]
     pub(crate) async fn get_resources<T>(
         _resources: FnvHashSet<Resource>,
@@ -109,8 +109,6 @@ impl Fetch {
             "{}/../examples/websocket-relay/synthcat.png",
             env!("CARGO_MANIFEST_DIR")
         ));
-
-        println!("Running in test mode: {}", img_path.display());
 
         let bytes = crate::tasks::WasmContext::load(wasm_path).await.unwrap();
         let buf = crate::tasks::WasmContext::load(img_path).await.unwrap();

--- a/homestar-runtime/src/test_utils/event.rs
+++ b/homestar-runtime/src/test_utils/event.rs
@@ -4,9 +4,8 @@ use crate::{
     settings,
     worker::WorkerMessage,
 };
-use tokio::sync::mpsc;
 
-/// Create an [mpsc::Sender], [mpsc::Receiver] pair for [Event]s.
+/// Create an [AsynBoundedChannelSender], [AsyncBoundedChannelReceiver] pair for [Event]s.
 pub(crate) fn setup_event_channel(
     settings: settings::Node,
 ) -> (
@@ -16,9 +15,12 @@ pub(crate) fn setup_event_channel(
     AsyncBoundedChannel::with(settings.network.events_buffer_len)
 }
 
-/// Create an [mpsc::Sender], [mpsc::Receiver] pair for worker messages.
+/// Create an [AsyncBoundedChannelSender], [AsyncBoundedChannelReceiver] pair for worker messages.
 pub(crate) fn setup_worker_channel(
     settings: settings::Node,
-) -> (mpsc::Sender<WorkerMessage>, mpsc::Receiver<WorkerMessage>) {
-    mpsc::channel(settings.network.events_buffer_len)
+) -> (
+    AsyncBoundedChannelSender<WorkerMessage>,
+    AsyncBoundedChannelReceiver<WorkerMessage>,
+) {
+    AsyncBoundedChannel::with(settings.network.events_buffer_len)
 }

--- a/homestar-runtime/src/test_utils/proc_macro/src/lib.rs
+++ b/homestar-runtime/src/test_utils/proc_macro/src/lib.rs
@@ -102,6 +102,7 @@ pub fn runner_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     settings.node.network.rpc_port = ::homestar_core::test_utils::ports::get_port() as u16;
                     settings.node.network.metrics_port = ::homestar_core::test_utils::ports::get_port() as u16;
                     settings.node.db.url = Some(format!("{}.db", #func_name_as_string));
+                    settings.node.network.websocket_receiver_timeout = std::time::Duration::from_millis(500);
                     let db = crate::test_utils::db::MemoryDb::setup_connection_pool(&settings.node, None).unwrap();
                     let runner = crate::Runner::start(settings.clone(), db).unwrap();
                     TestRunner { runner, settings }

--- a/homestar-runtime/src/test_utils/worker_builder.rs
+++ b/homestar-runtime/src/test_utils/worker_builder.rs
@@ -24,7 +24,6 @@ use homestar_core::{
 use homestar_wasm::io::Arg;
 use indexmap::IndexMap;
 use libipld::Cid;
-use tokio::sync::mpsc;
 
 /// TODO
 #[cfg(feature = "ipfs")]
@@ -32,7 +31,7 @@ pub(crate) struct WorkerBuilder<'a> {
     db: MemoryDb,
     event_sender: AsyncBoundedChannelSender<Event>,
     ipfs: IpfsCli,
-    runner_sender: mpsc::Sender<WorkerMessage>,
+    runner_sender: AsyncBoundedChannelSender<WorkerMessage>,
     name: Option<String>,
     workflow: Workflow<'a, Arg>,
     workflow_settings: workflow::Settings,
@@ -43,7 +42,7 @@ pub(crate) struct WorkerBuilder<'a> {
 pub(crate) struct WorkerBuilder<'a> {
     db: MemoryDb,
     event_sender: AsyncBoundedChannelSender<Event>,
-    runner_sender: mpsc::Sender<WorkerMessage>,
+    runner_sender: AsyncBoundedChannelSender<WorkerMessage>,
     name: Option<String>,
     workflow: Workflow<'a, Arg>,
     workflow_settings: workflow::Settings,
@@ -174,7 +173,7 @@ impl<'a> WorkerBuilder<'a> {
         self
     }
 
-    /// Build a [Worker] with a specific Event [mpsc::Sender].
+    /// Build a [Worker] with a specific Event [AsyncBoundedChannelSender].
     #[allow(dead_code)]
     pub(crate) fn with_event_sender(
         mut self,

--- a/homestar-runtime/src/worker.rs
+++ b/homestar-runtime/src/worker.rs
@@ -45,7 +45,7 @@ use indexmap::IndexMap;
 use libipld::{Cid, Ipld};
 use std::{collections::BTreeMap, sync::Arc};
 use tokio::{
-    sync::{mpsc, RwLock},
+    sync::RwLock,
     task::JoinSet,
     time::{self, Instant},
 };
@@ -66,7 +66,7 @@ pub(crate) enum WorkerMessage {
 pub(crate) struct Worker<'a, DB: Database> {
     pub(crate) graph: Arc<ExecutionGraph<'a>>,
     pub(crate) event_sender: Arc<AsyncBoundedChannelSender<Event>>,
-    pub(crate) runner_sender: mpsc::Sender<WorkerMessage>,
+    pub(crate) runner_sender: AsyncBoundedChannelSender<WorkerMessage>,
     pub(crate) db: DB,
     pub(crate) workflow_name: FastStr,
     pub(crate) workflow_info: Arc<workflow::Info>,
@@ -88,7 +88,7 @@ where
         // Name would be runner specific, separated from core workflow spec.
         name: Option<S>,
         event_sender: Arc<AsyncBoundedChannelSender<Event>>,
-        runner_sender: mpsc::Sender<WorkerMessage>,
+        runner_sender: AsyncBoundedChannelSender<WorkerMessage>,
         db: DB,
     ) -> Result<Worker<'a, DB>> {
         let p2p_timeout = settings.p2p_timeout;

--- a/homestar-runtime/src/workflow/settings.rs
+++ b/homestar-runtime/src/workflow/settings.rs
@@ -31,7 +31,7 @@ impl Default for Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            retries: 3,
+            retries: 0,
             retry_max_delay: Duration::new(1, 0),
             retry_initial_delay: Duration::from_millis(50),
             p2p_timeout: Duration::from_millis(10),

--- a/homestar-runtime/tests/cli.rs
+++ b/homestar-runtime/tests/cli.rs
@@ -284,49 +284,10 @@ fn test_daemon_serial() -> Result<()> {
 
 #[test]
 #[file_serial]
-#[cfg(windows)]
-fn test_signal_kill_serial() -> Result<()> {
-    let _ = stop_homestar();
-
-    let homestar_proc = Command::new(BIN.as_os_str())
-        .arg("start")
-        .arg("-c")
-        .arg("tests/fixtures/test_windows_v4.toml")
-        .arg("--db")
-        .arg("homestar.db")
-        .stdout(Stdio::piped())
-        .spawn()
-        .unwrap();
-
-    if wait_for_socket_connection(9001, 1000).is_err() {
-        let _ = kill_homestar(homestar_proc, None);
-        panic!("Homestar server/runtime failed to start in time");
-    }
-
-    Command::new(BIN.as_os_str())
-        .arg("ping")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("::1"))
-        .stdout(predicate::str::contains("pong"));
-
-    let _ = Command::new(BIN.as_os_str()).arg("stop").output();
-    let _ = kill_homestar(homestar_proc, None);
-
-    Command::new(BIN.as_os_str()).arg("ping").assert().failure();
-
-    let _ = stop_homestar();
-
-    Ok(())
-}
-
-#[test]
-#[file_serial]
-#[cfg(windows)]
 fn test_server_v4_serial() -> Result<()> {
     let _ = stop_homestar();
 
-    let mut homestar_proc = Command::new(BIN.as_os_str())
+    let homestar_proc = Command::new(BIN.as_os_str())
         .arg("start")
         .arg("-c")
         .arg("tests/fixtures/test_v4.toml")

--- a/homestar-runtime/tests/cli.rs
+++ b/homestar-runtime/tests/cli.rs
@@ -1,6 +1,8 @@
 #[cfg(not(windows))]
 use crate::utils::kill_homestar_daemon;
-use crate::utils::{kill_homestar, startup_ipfs, stop_all_bins, stop_homestar, BIN_NAME, IPFS};
+#[cfg(feature = "ipfs")]
+use crate::utils::startup_ipfs;
+use crate::utils::{kill_homestar, stop_all_bins, stop_homestar, BIN_NAME, IPFS};
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use once_cell::sync::Lazy;

--- a/homestar-runtime/tests/cli.rs
+++ b/homestar-runtime/tests/cli.rs
@@ -1,6 +1,6 @@
 #[cfg(not(windows))]
 use crate::utils::kill_homestar_daemon;
-use crate::utils::{kill_homestar, stop_homestar, BIN_NAME};
+use crate::utils::{kill_homestar, startup_ipfs, stop_all_bins, stop_homestar, BIN_NAME, IPFS};
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use once_cell::sync::Lazy;
@@ -174,7 +174,25 @@ fn test_server_serial() -> Result<()> {
 #[test]
 #[file_serial]
 fn test_workflow_run_serial() -> Result<()> {
-    let _ = stop_homestar();
+    const IPFS_EXT: &str = "test_libp2p_receipt_gossip_serial";
+
+    let _ = stop_all_bins();
+
+    #[cfg(feature = "ipfs")]
+    let _ = startup_ipfs(IPFS_EXT);
+
+    let add_wasm_args = vec![
+        "add",
+        "--cid-version",
+        "1",
+        "../homestar-wasm/fixtures/example_add.wasm",
+    ];
+
+    let _ipfs_add_wasm = Command::new(IPFS)
+        .args(add_wasm_args)
+        .stdout(Stdio::piped())
+        .output()
+        .expect("`ipfs add` of wasm mod");
 
     let mut homestar_proc = Command::new(BIN.as_os_str())
         .arg("start")

--- a/homestar-runtime/tests/fixtures/test-workflow-add-one.json
+++ b/homestar-runtime/tests/fixtures/test-workflow-add-one.json
@@ -17,7 +17,7 @@
         },
         "nnc": "",
         "op": "wasm/run",
-        "rsc": "ipfs://bafkreidgxzucs63ums2yhzs4unin5a3vjemapc373rypon63kdp5xoqlzm"
+        "rsc": "ipfs://bafybeiczefaiu7464ehupezpzulnti5jvcwnvdalqrdliugnnwcdz6ljia"
       }
     },
     {
@@ -33,7 +33,7 @@
           "args": [
             {
               "await/ok": {
-                "/": "bafyrmigpbec3fpc64hxkehxkszctb5f5roylk5ej2t2qgfylf64gpdn54m"
+                "/": "bafyrmid5morwzj3lz436g44usvu35xcfyn4ommfe4ozulmnrsohybdez3a"
               }
             }
           ],
@@ -41,7 +41,7 @@
         },
         "nnc": "",
         "op": "wasm/run",
-        "rsc": "ipfs://bafkreidgxzucs63ums2yhzs4unin5a3vjemapc373rypon63kdp5xoqlzm"
+        "rsc": "ipfs://bafybeiczefaiu7464ehupezpzulnti5jvcwnvdalqrdliugnnwcdz6ljia"
       }
     }
   ]

--- a/homestar-runtime/tests/fixtures/test_gossip1.toml
+++ b/homestar-runtime/tests/fixtures/test_gossip1.toml
@@ -1,0 +1,20 @@
+[monitoring]
+process_collector_interval = 500
+console_subscriber_port = 5550
+
+[node]
+
+[node.network]
+metrics_port = 3990
+rpc_port = 9790
+webserver_port = 7990
+listen_address = "/ip4/127.0.0.1/tcp/7020"
+node_addresses = [
+  "/ip4/127.0.0.1/tcp/7021/p2p/16Uiu2HAm3g9AomQNeEctL2hPwLapap7AtPSNt8ZrBny4rLx1W5Dc",
+]
+enable_mdns = false
+enable_rendezvous_client = false
+
+# Peer ID 12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN
+[node.network.keypair_config]
+existing = { key_type = "ed25519", path = "./fixtures/__testkey_ed25519.pem" }

--- a/homestar-runtime/tests/fixtures/test_gossip2.toml
+++ b/homestar-runtime/tests/fixtures/test_gossip2.toml
@@ -1,0 +1,20 @@
+[monitoring]
+process_collector_interval = 500
+console_subscriber_port = 5551
+
+[node]
+
+[node.network]
+metrics_port = 3991
+rpc_port = 9791
+webserver_port = 7991
+listen_address = "/ip4/127.0.0.1/tcp/7021"
+node_addresses = [
+  "/ip4/127.0.0.1/tcp/7020/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN",
+]
+enable_mdns = false
+enable_rendezvous_client = false
+
+# Peer ID 16Uiu2HAm3g9AomQNeEctL2hPwLapap7AtPSNt8ZrBny4rLx1W5Dc
+[node.network.keypair_config]
+existing = { key_type = "secp256k1", path = "./fixtures/__testkey_secp256k1.der" }

--- a/homestar-runtime/tests/fixtures/test_windows_v4.toml
+++ b/homestar-runtime/tests/fixtures/test_windows_v4.toml
@@ -1,12 +1,12 @@
 [monitoring]
 process_collector_interval = 500
-console_subscriber_port = 5590
+console_subscriber_port = 5591
 
 [node]
 
 [node.network]
-metrics_port = 4045
+metrics_port = 4046
 events_buffer_len = 1000
-rpc_port = 9000
+rpc_port = 9001
 rpc_host = "127.0.0.1"
-webserver_port = 8031
+webserver_port = 8032

--- a/homestar-runtime/tests/network.rs
+++ b/homestar-runtime/tests/network.rs
@@ -11,6 +11,7 @@ use std::{
     time::Duration,
 };
 
+#[cfg(feature = "websocket-notify")]
 mod gossip;
 #[cfg(feature = "websocket-notify")]
 mod notification;

--- a/homestar-runtime/tests/network.rs
+++ b/homestar-runtime/tests/network.rs
@@ -1,5 +1,6 @@
 use crate::utils::{
-    check_lines_for, count_lines_where, kill_homestar, retrieve_output, stop_homestar, BIN_NAME,
+    check_lines_for, count_lines_where, kill_homestar, retrieve_output, stop_homestar,
+    wait_for_socket_connection, wait_for_socket_connection_v6, BIN_NAME,
 };
 use anyhow::Result;
 use once_cell::sync::Lazy;
@@ -34,6 +35,11 @@ fn test_libp2p_generates_peer_id_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection_v6(9820, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     let dead_proc = kill_homestar(homestar_proc, None);
     let stdout = retrieve_output(dead_proc);
     let logs_expected = check_lines_for(
@@ -63,6 +69,11 @@ fn test_libp2p_listens_on_address_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection_v6(9820, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     let dead_proc = kill_homestar(homestar_proc, None);
     let stdout = retrieve_output(dead_proc);
@@ -95,6 +106,11 @@ fn test_rpc_listens_on_address_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection_v6(9820, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     let dead_proc = kill_homestar(homestar_proc, None);
     let stdout = retrieve_output(dead_proc);
     let logs_expected = check_lines_for(stdout, vec!["RPC server listening", "[::1]:9820"]);
@@ -118,6 +134,11 @@ fn test_websocket_listens_on_address_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection_v6(9820, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     let dead_proc = kill_homestar(homestar_proc, None);
     let stdout = retrieve_output(dead_proc);
@@ -149,6 +170,11 @@ fn test_libp2p_connect_known_peers_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection_v6(9820, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     let homestar_proc2 = Command::new(BIN.as_os_str())
         .env(
             "RUST_LOG",
@@ -162,6 +188,11 @@ fn test_libp2p_connect_known_peers_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection_v6(9821, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc2, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Collect logs for five seconds then kill proceses.
     let dead_proc1 = kill_homestar(homestar_proc1, Some(Duration::from_secs(5)));
@@ -257,6 +288,11 @@ fn test_libp2p_connect_after_mdns_discovery_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection_v6(9800, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     let homestar_proc2 = Command::new(BIN.as_os_str())
         .env(
             "RUST_LOG",
@@ -270,6 +306,11 @@ fn test_libp2p_connect_after_mdns_discovery_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection_v6(9801, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc2, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Collect logs for seven seconds then kill processes.
     let dead_proc1 = kill_homestar(homestar_proc1, Some(Duration::from_secs(7)));
@@ -364,6 +405,11 @@ fn test_libp2p_connect_rendezvous_discovery_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection(8024, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_server, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     // Start a peer that will register with the rendezvous server
     let rendezvous_client1 = Command::new(BIN.as_os_str())
         .env(
@@ -378,6 +424,11 @@ fn test_libp2p_connect_rendezvous_discovery_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection(8026, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_client1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Wait for registration to complete
     // TODO When we have websocket push events, listen on a registration event instead of using an arbitrary sleep
@@ -397,6 +448,11 @@ fn test_libp2p_connect_rendezvous_discovery_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection(8027, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_client2, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Collect logs for five seconds then kill proceses.
     let dead_server = kill_homestar(rendezvous_server, Some(Duration::from_secs(5)));
@@ -483,6 +539,11 @@ fn test_libp2p_disconnect_mdns_discovery_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection(8000, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     let homestar_proc2 = Command::new(BIN.as_os_str())
         .env(
             "RUST_LOG",
@@ -496,6 +557,11 @@ fn test_libp2p_disconnect_mdns_discovery_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection(8001, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc2, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Kill node two after seven seconds.
     let _ = kill_homestar(homestar_proc2, Some(Duration::from_secs(7)));
@@ -551,6 +617,11 @@ fn test_libp2p_disconnect_known_peers_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection_v6(9820, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     let homestar_proc2 = Command::new(BIN.as_os_str())
         .env(
             "RUST_LOG",
@@ -564,6 +635,11 @@ fn test_libp2p_disconnect_known_peers_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection_v6(9821, 1000).is_err() {
+        let _ = kill_homestar(homestar_proc2, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Kill node two after seven seconds.
     let _ = kill_homestar(homestar_proc2, Some(Duration::from_secs(7)));
@@ -618,6 +694,11 @@ fn test_libp2p_disconnect_rendezvous_discovery_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection(8024, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_server, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     // Start a peer that will register with the rendezvous server
     let rendezvous_client1 = Command::new(BIN.as_os_str())
         .env(
@@ -632,6 +713,11 @@ fn test_libp2p_disconnect_rendezvous_discovery_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection(8026, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_client1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Wait for registration to complete.
     // TODO When we have websocket push events, listen on a registration event instead of using an arbitrary sleep.
@@ -651,6 +737,11 @@ fn test_libp2p_disconnect_rendezvous_discovery_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection(8027, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_client1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Kill server and client one after five seconds
     let _ = kill_homestar(rendezvous_server, Some(Duration::from_secs(5)));
@@ -706,6 +797,11 @@ fn test_libp2p_rendezvous_renew_registration_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection(8024, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_server, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     // Start a peer that will renew registrations with the rendezvous server once per second
     let rendezvous_client1 = Command::new(BIN.as_os_str())
         .env(
@@ -720,6 +816,11 @@ fn test_libp2p_rendezvous_renew_registration_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection(8028, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_client1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Collect logs for five seconds then kill proceses.
     let dead_server = kill_homestar(rendezvous_server, Some(Duration::from_secs(5)));
@@ -773,6 +874,11 @@ fn test_libp2p_rendezvous_rediscovery_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection(8024, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_server, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     // Start a peer that will discover with the rendezvous server once per second
     let rendezvous_client1 = Command::new(BIN.as_os_str())
         .env(
@@ -787,6 +893,11 @@ fn test_libp2p_rendezvous_rediscovery_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection_v6(9829, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_client1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Collect logs for five seconds then kill proceses.
     let dead_server = kill_homestar(rendezvous_server, Some(Duration::from_secs(5)));
@@ -840,6 +951,11 @@ fn test_libp2p_rendezvous_rediscover_on_expiration_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
+    if wait_for_socket_connection(8024, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_server, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
     // Start a peer that will renew registrations with the rendezvous server every five seconds
     let rendezvous_client1 = Command::new(BIN.as_os_str())
         .env(
@@ -854,6 +970,11 @@ fn test_libp2p_rendezvous_rediscover_on_expiration_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection_v6(9830, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_client1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Wait for registration to complete.
     // TODO When we have websocket push events, listen on a registration event instead of using an arbitrary sleep.
@@ -876,6 +997,11 @@ fn test_libp2p_rendezvous_rediscover_on_expiration_serial() -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+
+    if wait_for_socket_connection(8027, 1000).is_err() {
+        let _ = kill_homestar(rendezvous_client1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
     // Collect logs for seven seconds then kill proceses.
     let dead_server = kill_homestar(rendezvous_server, Some(Duration::from_secs(7)));

--- a/homestar-runtime/tests/network.rs
+++ b/homestar-runtime/tests/network.rs
@@ -11,6 +11,7 @@ use std::{
     time::Duration,
 };
 
+mod gossip;
 #[cfg(feature = "websocket-notify")]
 mod notification;
 

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use once_cell::sync::Lazy;
 use serial_test::file_serial;
 use std::{
-    fs,
     path::PathBuf,
     process::{Command, Stdio},
     thread,
@@ -97,6 +96,9 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
 
     assert!(message_published);
     assert!(message_received);
+
+    remove_db("homestar_test_libp2p_receipt_gossip_serial1");
+    remove_db("homestar_test_libp2p_receipt_gossip_serial2");
 
     let _ = stop_all_bins();
 

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -108,7 +108,7 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
 
         // Poll for connection established message
         loop {
-            if let Ok(msg) = sub1.next().with_timeout(Duration::from_secs(3)).await {
+            if let Ok(msg) = sub1.next().with_timeout(Duration::from_secs(10)).await {
                 let json: serde_json::Value =
                     serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
 
@@ -148,7 +148,7 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
         let mut published_cids: Vec<Cid> = vec![];
         let mut received_cids: Vec<Cid> = vec![];
         loop {
-            if let Ok(msg) = sub1.next().with_timeout(Duration::from_secs(3)).await {
+            if let Ok(msg) = sub1.next().with_timeout(Duration::from_secs(10)).await {
                 let json: serde_json::Value =
                     serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
 
@@ -162,7 +162,7 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
                 panic!("Node one did not publish receipt in time.")
             }
 
-            if let Ok(msg) = sub2.next().with_timeout(Duration::from_secs(3)).await {
+            if let Ok(msg) = sub2.next().with_timeout(Duration::from_secs(10)).await {
                 let json: serde_json::Value =
                     serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
 

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -1,0 +1,104 @@
+use crate::utils::{
+    check_lines_for, kill_homestar, remove_db, retrieve_output, startup_ipfs, stop_all_bins,
+    BIN_NAME, IPFS,
+};
+use anyhow::Result;
+use once_cell::sync::Lazy;
+use serial_test::file_serial;
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+    thread,
+    time::Duration,
+};
+
+static BIN: Lazy<PathBuf> = Lazy::new(|| assert_cmd::cargo::cargo_bin(BIN_NAME));
+
+#[test]
+#[file_serial]
+fn test_libp2p_receipt_gossip_serial() -> Result<()> {
+    let _ = stop_all_bins();
+
+    #[cfg(feature = "ipfs")]
+    let _ = startup_ipfs();
+
+    let add_wasm_args = vec![
+        "add",
+        "--cid-version",
+        "1",
+        "../homestar-wasm/fixtures/example_add.wasm",
+    ];
+
+    let _ipfs_add_wasm = Command::new(IPFS)
+        .args(add_wasm_args)
+        .stdout(Stdio::piped())
+        .output()
+        .expect("`ipfs add` of wasm mod");
+
+    let homestar_proc1 = Command::new(BIN.as_os_str())
+        .env(
+            "RUST_LOG",
+            "homestar=debug,homestar_runtime=debug,libp2p=debug,libp2p_gossipsub::behaviour=debug",
+        )
+        .arg("start")
+        .arg("-c")
+        .arg("tests/fixtures/test_gossip1.toml")
+        .arg("--db")
+        .arg("homestar_test_libp2p_receipt_gossip_serial1.db")
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let homestar_proc2 = Command::new(BIN.as_os_str())
+        .env(
+            "RUST_LOG",
+            "homestar=debug,homestar_runtime=debug,libp2p=debug,libp2p_gossipsub::behaviour=debug",
+        )
+        .arg("start")
+        .arg("-c")
+        .arg("tests/fixtures/test_gossip2.toml")
+        .arg("--db")
+        .arg("homestar_test_libp2p_receipt_gossip_serial2.db")
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Wait for nodes to be come online
+    thread::sleep(Duration::from_secs(2));
+
+    let _ = Command::new(BIN.as_os_str())
+        .arg("run")
+        .arg("-p")
+        .arg("9790")
+        .arg("-w")
+        .arg("tests/fixtures/test-workflow-add-one.json")
+        .output();
+
+    // Collect logs for ten seconds then kill proceses.
+    let dead_proc1 = kill_homestar(homestar_proc1, Some(Duration::from_secs(7)));
+    let dead_proc2 = kill_homestar(homestar_proc2, Some(Duration::from_secs(7)));
+
+    // Retrieve logs.
+    let stdout1 = retrieve_output(dead_proc1);
+    let stdout2 = retrieve_output(dead_proc2);
+
+    // Check node one published a receipt
+    let message_published = check_lines_for(stdout1, vec!["message published on receipts topic"]);
+
+    // Check node two received a receipt from node one
+    let message_received = check_lines_for(
+        stdout2,
+        vec![
+            "message received on receipts topic",
+            "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN",
+        ],
+    );
+
+    assert!(message_published);
+    assert!(message_received);
+
+    let _ = stop_all_bins();
+
+    Ok(())
+}

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -28,10 +28,14 @@ const UNSUBSCRIBE_NETWORK_EVENTS_ENDPOINT: &str = "unsubscribe_network_events";
 #[test]
 #[file_serial]
 fn test_libp2p_receipt_gossip_serial() -> Result<()> {
+    const IPFS_EXT: &str = "test_libp2p_receipt_gossip_serial";
+    const DB1: &str = "homestar_test_libp2p_receipt_gossip_serial1.db";
+    const DB2: &str = "homestar_test_libp2p_receipt_gossip_serial2.db";
+
     let _ = stop_all_bins();
 
     #[cfg(feature = "ipfs")]
-    let _ = startup_ipfs();
+    let _ = startup_ipfs(IPFS_EXT);
 
     let add_wasm_args = vec![
         "add",
@@ -55,7 +59,7 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_gossip1.toml")
         .arg("--db")
-        .arg("homestar_test_libp2p_receipt_gossip_serial1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -91,7 +95,7 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
             .arg("-c")
             .arg("tests/fixtures/test_gossip2.toml")
             .arg("--db")
-            .arg("homestar_test_libp2p_receipt_gossip_serial2.db")
+            .arg(DB2)
             .stdout(Stdio::piped())
             .spawn()
             .unwrap();
@@ -198,11 +202,8 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
 
         let settings =
             Settings::load_from_file(PathBuf::from("tests/fixtures/test_gossip2.toml")).unwrap();
-        let db = Db::setup_connection_pool(
-            settings.node(),
-            Some("homestar_test_libp2p_receipt_gossip_serial2.db".to_string()),
-        )
-        .expect("Failed to connect to node two database");
+        let db = Db::setup_connection_pool(settings.node(), Some(DB2.to_string()))
+            .expect("Failed to connect to node two database");
 
         // Check database for stored receipts
         let stored_receipts: Vec<_> = received_cids
@@ -217,8 +218,8 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
         assert_eq!(stored_receipts.len(), 2)
     });
 
-    remove_db("homestar_test_libp2p_receipt_gossip_serial1");
-    remove_db("homestar_test_libp2p_receipt_gossip_serial2");
+    remove_db(DB1);
+    remove_db(DB2);
 
     let _ = stop_all_bins();
 

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    check_lines_for, kill_homestar, remove_db, retrieve_output, startup_ipfs, stop_all_bins,
-    wait_for_socket_connection, TimeoutFutureExt, BIN_NAME, IPFS,
+    check_lines_for, kill_homestar, remove_db, retrieve_output, stop_homestar,
+    wait_for_socket_connection, TimeoutFutureExt, BIN_NAME,
 };
 use anyhow::Result;
 use homestar_runtime::{db::Database, Db, Settings};
@@ -28,28 +28,9 @@ const UNSUBSCRIBE_NETWORK_EVENTS_ENDPOINT: &str = "unsubscribe_network_events";
 #[test]
 #[file_serial]
 fn test_libp2p_receipt_gossip_serial() -> Result<()> {
-    const IPFS_EXT: &str = "test_libp2p_receipt_gossip_serial";
     const DB1: &str = "homestar_test_libp2p_receipt_gossip_serial1.db";
     const DB2: &str = "homestar_test_libp2p_receipt_gossip_serial2.db";
-
-    let _ = stop_all_bins();
-
-    #[cfg(feature = "ipfs")]
-    let _ = startup_ipfs(IPFS_EXT);
-
-    let add_wasm_args = vec![
-        "add",
-        "--cid-version",
-        "1",
-        "../homestar-wasm/fixtures/example_add.wasm",
-    ];
-
-    let _ipfs_add_wasm = Command::new(IPFS)
-        .args(add_wasm_args)
-        .stdout(Stdio::piped())
-        .output()
-        .expect("`ipfs add` of wasm mod");
-
+    let _ = stop_homestar();
     let homestar_proc1 = Command::new(BIN.as_os_str())
         .env(
             "RUST_LOG",
@@ -226,7 +207,7 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
     remove_db(DB1);
     remove_db(DB2);
 
-    let _ = stop_all_bins();
+    let _ = stop_homestar();
 
     Ok(())
 }

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -89,7 +89,7 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
 
         // Poll for connection established message
         loop {
-            if let Ok(msg) = sub1.next().with_timeout(Duration::from_secs(10)).await {
+            if let Ok(msg) = sub1.next().with_timeout(Duration::from_secs(30)).await {
                 let json: serde_json::Value =
                     serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
 
@@ -129,7 +129,7 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
         let mut published_cids: Vec<Cid> = vec![];
         let mut received_cids: Vec<Cid> = vec![];
         loop {
-            if let Ok(msg) = sub1.next().with_timeout(Duration::from_secs(10)).await {
+            if let Ok(msg) = sub1.next().with_timeout(Duration::from_secs(30)).await {
                 let json: serde_json::Value =
                     serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
 
@@ -143,7 +143,7 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
                 panic!("Node one did not publish receipt in time.")
             }
 
-            if let Ok(msg) = sub2.next().with_timeout(Duration::from_secs(10)).await {
+            if let Ok(msg) = sub2.next().with_timeout(Duration::from_secs(30)).await {
                 let json: serde_json::Value =
                     serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
 

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -1,18 +1,26 @@
 use crate::utils::{
     check_lines_for, kill_homestar, remove_db, retrieve_output, startup_ipfs, stop_all_bins,
-    BIN_NAME, IPFS,
+    wait_for_socket_connection, BIN_NAME, IPFS,
 };
 use anyhow::Result;
+use jsonrpsee::{
+    core::client::{Subscription, SubscriptionClientT},
+    rpc_params,
+    ws_client::WsClientBuilder,
+};
 use once_cell::sync::Lazy;
 use serial_test::file_serial;
 use std::{
+    net::Ipv4Addr,
     path::PathBuf,
     process::{Command, Stdio},
-    thread,
     time::Duration,
 };
+use tokio::time::timeout;
 
 static BIN: Lazy<PathBuf> = Lazy::new(|| assert_cmd::cargo::cargo_bin(BIN_NAME));
+const SUBSCRIBE_NETWORK_EVENTS_ENDPOINT: &str = "subscribe_network_events";
+const UNSUBSCRIBE_NETWORK_EVENTS_ENDPOINT: &str = "unsubscribe_network_events";
 
 #[test]
 #[file_serial]
@@ -49,53 +57,89 @@ fn test_libp2p_receipt_gossip_serial() -> Result<()> {
         .spawn()
         .unwrap();
 
-    let homestar_proc2 = Command::new(BIN.as_os_str())
-        .env(
-            "RUST_LOG",
-            "homestar=debug,homestar_runtime=debug,libp2p=debug,libp2p_gossipsub::behaviour=debug",
-        )
-        .arg("start")
-        .arg("-c")
-        .arg("tests/fixtures/test_gossip2.toml")
-        .arg("--db")
-        .arg("homestar_test_libp2p_receipt_gossip_serial2.db")
-        .stdout(Stdio::piped())
-        .spawn()
-        .unwrap();
+    let ws_port = 7990;
+    if let Err(_) = wait_for_socket_connection(ws_port, 1000) {
+        let _ = kill_homestar(homestar_proc1, None);
+        panic!("Homestar server/runtime failed to start in time");
+    }
 
-    // Wait for nodes to be come online
-    thread::sleep(Duration::from_secs(2));
+    tokio_test::block_on(async {
+        let ws_url = format!("ws://{}:{}", Ipv4Addr::LOCALHOST, ws_port);
+        let client = WsClientBuilder::default()
+            .build(ws_url.clone())
+            .await
+            .unwrap();
 
-    let _ = Command::new(BIN.as_os_str())
-        .arg("run")
-        .arg("-p")
-        .arg("9790")
-        .arg("-w")
-        .arg("tests/fixtures/test-workflow-add-one.json")
-        .output();
+        let mut sub: Subscription<Vec<u8>> = client
+            .subscribe(
+                SUBSCRIBE_NETWORK_EVENTS_ENDPOINT,
+                rpc_params![],
+                UNSUBSCRIBE_NETWORK_EVENTS_ENDPOINT,
+            )
+            .await
+            .unwrap();
 
-    // Collect logs for ten seconds then kill proceses.
-    let dead_proc1 = kill_homestar(homestar_proc1, Some(Duration::from_secs(7)));
-    let dead_proc2 = kill_homestar(homestar_proc2, Some(Duration::from_secs(7)));
+        let homestar_proc2 = Command::new(BIN.as_os_str())
+            .env(
+                "RUST_LOG",
+                "homestar=debug,homestar_runtime=debug,libp2p=debug,libp2p_gossipsub::behaviour=debug",
+            )
+            .arg("start")
+            .arg("-c")
+            .arg("tests/fixtures/test_gossip2.toml")
+            .arg("--db")
+            .arg("homestar_test_libp2p_receipt_gossip_serial2.db")
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
 
-    // Retrieve logs.
-    let stdout1 = retrieve_output(dead_proc1);
-    let stdout2 = retrieve_output(dead_proc2);
+        // Poll for connection established message
+        loop {
+            if let Ok(msg) = timeout(Duration::from_secs(3), sub.next()).await {
+                let json: serde_json::Value =
+                    serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
 
-    // Check node one published a receipt
-    let message_published = check_lines_for(stdout1, vec!["message published on receipts topic"]);
+                if json["type"].as_str().unwrap() == "network:connectionEstablished" {
+                    break;
+                }
+            } else {
+                panic!("Node one did not establish a connection with node two in time.")
+            }
+        }
 
-    // Check node two received a receipt from node one
-    let message_received = check_lines_for(
-        stdout2,
-        vec![
-            "message received on receipts topic",
-            "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN",
-        ],
-    );
+        // Run test workflow
+        let _ = Command::new(BIN.as_os_str())
+            .arg("run")
+            .arg("-p")
+            .arg("9790")
+            .arg("-w")
+            .arg("tests/fixtures/test-workflow-add-one.json")
+            .output();
 
-    assert!(message_published);
-    assert!(message_received);
+        // Collect logs for seven seconds then kill proceses.
+        let dead_proc1 = kill_homestar(homestar_proc1, Some(Duration::from_secs(7)));
+        let dead_proc2 = kill_homestar(homestar_proc2, Some(Duration::from_secs(7)));
+
+        // Retrieve logs.
+        let stdout1 = retrieve_output(dead_proc1);
+        let stdout2 = retrieve_output(dead_proc2);
+
+        // Check node one published a receipt
+        let message_published =
+            check_lines_for(stdout1, vec!["message published on receipts topic"]);
+
+        // Check node two received a receipt from node one
+        let message_received = check_lines_for(
+            stdout2,
+            vec![
+                "message received on receipts topic",
+                "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN",
+            ],
+        );
+
+        assert!(message_published);
+        assert!(message_received);
+    });
 
     remove_db("homestar_test_libp2p_receipt_gossip_serial1");
     remove_db("homestar_test_libp2p_receipt_gossip_serial2");

--- a/homestar-runtime/tests/network/notification.rs
+++ b/homestar-runtime/tests/network/notification.rs
@@ -95,7 +95,7 @@ fn test_connection_notifications_serial() -> Result<()> {
                 .expect("Subscription did not receive a connection established message");
             let json: serde_json::Value = serde_json::from_slice(&msg.unwrap()).unwrap();
             let typ = json["type"].as_str().unwrap();
-            let peer_id = json["data"]["peer_id"].as_str().unwrap();
+            let peer_id = json["data"]["peerId"].as_str().unwrap();
 
             assert_eq!(typ, "network:connectionEstablished");
             assert_eq!(
@@ -111,7 +111,7 @@ fn test_connection_notifications_serial() -> Result<()> {
                 .expect("Subscription did not receive a connection closed message");
             let json: serde_json::Value = serde_json::from_slice(&msg.unwrap()).unwrap();
             let typ = json["type"].as_str().unwrap();
-            let peer_id = json["data"]["peer_id"].as_str().unwrap();
+            let peer_id = json["data"]["peerId"].as_str().unwrap();
 
             assert_eq!(typ, "network:connectionClosed");
             assert_eq!(

--- a/homestar-runtime/tests/utils.rs
+++ b/homestar-runtime/tests/utils.rs
@@ -13,11 +13,10 @@ use retry::{
     delay::{Exponential, Fixed},
     retry,
 };
-#[cfg(feature = "ipfs")]
-use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpStream};
 use std::{
     fs,
     future::Future,
+    net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpStream},
     path::PathBuf,
     process::{Child, Command, Stdio},
     time::Duration,

--- a/homestar-runtime/tests/utils.rs
+++ b/homestar-runtime/tests/utils.rs
@@ -46,14 +46,9 @@ pub(crate) fn startup_ipfs(ext: &str) -> Result<()> {
         .spawn()?;
 
     // wait for ipfs daemon to start by testing for a connection
-    let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5001);
-    let result = retry(Fixed::from_millis(500), || {
-        TcpStream::connect(socket).map(|stream| stream.shutdown(Shutdown::Both))
-    });
-
-    if let Err(err) = result {
+    if wait_for_socket_connection(5001, 1000).is_err() {
         ipfs_daemon.kill().unwrap();
-        panic!("`ipfs daemon` failed to start: {:?}", err);
+        panic!("`ipfs daemon` failed to start");
     } else {
         Ok(())
     }

--- a/homestar-runtime/tests/utils.rs
+++ b/homestar-runtime/tests/utils.rs
@@ -227,9 +227,9 @@ pub(crate) fn kill_homestar_daemon() -> Result<()> {
 
 /// Remove sqlite database and associated temporary files
 pub(crate) fn remove_db(name: &str) {
-    let _ = fs::remove_file(format!("{name}.db"));
-    let _ = fs::remove_file(format!("{name}.db-shm"));
-    let _ = fs::remove_file(format!("{name}.db-wal"));
+    let _ = fs::remove_file(format!("{name}"));
+    let _ = fs::remove_file(format!("{name}-shm"));
+    let _ = fs::remove_file(format!("{name}-wal"));
 }
 
 /// Wait for socket connection or timeout

--- a/homestar-runtime/tests/utils.rs
+++ b/homestar-runtime/tests/utils.rs
@@ -124,10 +124,9 @@ pub(crate) fn extract_timestamps_where(
     output: String,
     predicates: Vec<&str>,
 ) -> Vec<DateTime<FixedOffset>> {
-    output.split("\n").fold(vec![], |mut timestamps, line| {
+    output.split('\n').fold(vec![], |mut timestamps, line| {
         if line_contains(line, &predicates) {
-            match extract_label(&line, "ts").and_then(|val| DateTime::parse_from_rfc3339(val).ok())
-            {
+            match extract_label(line, "ts").and_then(|val| DateTime::parse_from_rfc3339(val).ok()) {
                 Some(datetime) => {
                     timestamps.push(datetime);
                     timestamps
@@ -144,11 +143,11 @@ pub(crate) fn extract_timestamps_where(
 }
 
 /// Check process output line for all predicates
-fn line_contains(line: &str, predicates: &Vec<&str>) -> bool {
+fn line_contains(line: &str, predicates: &[&str]) -> bool {
     predicates
         .iter()
         .map(|pred| predicate::str::contains(*pred).eval(line))
-        .fold(true, |acc, curr| acc && curr)
+        .all(|curr| curr)
 }
 
 /// Extract label value from process output line
@@ -226,7 +225,7 @@ pub(crate) fn kill_homestar_daemon() -> Result<()> {
 
 /// Remove sqlite database and associated temporary files
 pub(crate) fn remove_db(name: &str) {
-    let _ = fs::remove_file(format!("{name}"));
+    let _ = fs::remove_file(name);
     let _ = fs::remove_file(format!("{name}-shm"));
     let _ = fs::remove_file(format!("{name}-wal"));
 }

--- a/homestar-runtime/tests/utils.rs
+++ b/homestar-runtime/tests/utils.rs
@@ -13,6 +13,7 @@ use retry::{delay::Fixed, retry};
 #[cfg(feature = "ipfs")]
 use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpStream};
 use std::{
+    fs,
     future::Future,
     path::PathBuf,
     process::{Child, Command, Stdio},
@@ -219,6 +220,12 @@ pub(crate) fn kill_homestar_daemon() -> Result<()> {
     };
 
     Ok(())
+}
+
+pub(crate) fn remove_db(name: &str) {
+    let _ = fs::remove_file(format!("{name}.db"));
+    let _ = fs::remove_file(format!("{name}.db-shm"));
+    let _ = fs::remove_file(format!("{name}.db-wal"));
 }
 
 /// Helper extension trait which allows to limit execution time for the futures.

--- a/homestar-runtime/tests/utils.rs
+++ b/homestar-runtime/tests/utils.rs
@@ -9,10 +9,9 @@ use nix::{
 };
 use once_cell::sync::Lazy;
 use predicates::prelude::*;
-use retry::{
-    delay::{Exponential, Fixed},
-    retry,
-};
+#[cfg(not(windows))]
+use retry::delay::Fixed;
+use retry::{delay::Exponential, retry};
 use std::{
     fs,
     future::Future,

--- a/homestar-runtime/tests/webserver.rs
+++ b/homestar-runtime/tests/webserver.rs
@@ -99,7 +99,7 @@ fn test_workflow_run_serial() -> Result<()> {
             .unwrap();
 
         loop {
-            if let Ok(msg) = sub2.next().with_timeout(Duration::from_secs(10)).await {
+            if let Ok(msg) = sub2.next().with_timeout(Duration::from_secs(30)).await {
                 let json: serde_json::Value =
                     serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
                 let check = json.get("metadata").unwrap();
@@ -128,12 +128,12 @@ fn test_workflow_run_serial() -> Result<()> {
 
         let _ = sub2
             .next()
-            .with_timeout(Duration::from_secs(10))
+            .with_timeout(Duration::from_secs(30))
             .await
             .is_err();
 
         loop {
-            if let Ok(msg) = sub3.next().with_timeout(Duration::from_secs(10)).await {
+            if let Ok(msg) = sub3.next().with_timeout(Duration::from_secs(30)).await {
                 let json: serde_json::Value =
                     serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
                 let check = json.get("metadata").unwrap();
@@ -168,7 +168,7 @@ fn test_workflow_run_serial() -> Result<()> {
             .unwrap();
 
         loop {
-            if let Ok(msg) = sub4.next().with_timeout(Duration::from_secs(10)).await {
+            if let Ok(msg) = sub4.next().with_timeout(Duration::from_secs(30)).await {
                 let json: serde_json::Value =
                     serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
                 let check = json.get("metadata").unwrap();

--- a/homestar-runtime/tests/webserver.rs
+++ b/homestar-runtime/tests/webserver.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "ipfs")]
 use crate::utils::startup_ipfs;
-use crate::utils::{kill_homestar, stop_all_bins, TimeoutFutureExt, BIN_NAME, IPFS};
+use crate::utils::{kill_homestar, remove_db, stop_all_bins, TimeoutFutureExt, BIN_NAME, IPFS};
 use anyhow::Result;
 use jsonrpsee::{
     core::client::{Subscription, SubscriptionClientT},
@@ -244,7 +244,7 @@ fn test_workflow_run_serial() -> Result<()> {
     let _ = Command::new(BIN.as_os_str()).arg("stop").output();
     let _ = kill_homestar(homestar_proc, None);
     let _ = stop_all_bins();
-    let _ = fs::remove_file(DB);
+    remove_db(DB);
 
     Ok(())
 }

--- a/homestar-runtime/tests/webserver.rs
+++ b/homestar-runtime/tests/webserver.rs
@@ -69,7 +69,7 @@ fn test_workflow_run_serial() -> Result<()> {
         .arg("tests/fixtures/test_workflow2.toml")
         .arg("--db")
         .arg(DB)
-        .stdout(Stdio::piped())
+        //.stdout(Stdio::piped())
         .spawn()
         .unwrap();
 

--- a/homestar-runtime/tests/webserver.rs
+++ b/homestar-runtime/tests/webserver.rs
@@ -106,7 +106,7 @@ fn test_workflow_run_serial() -> Result<()> {
         // we have 3 operations
         let one = sub1
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&one.unwrap().unwrap()).unwrap();
@@ -116,7 +116,7 @@ fn test_workflow_run_serial() -> Result<()> {
 
         let two = sub1
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&two.unwrap().unwrap()).unwrap();
@@ -126,7 +126,7 @@ fn test_workflow_run_serial() -> Result<()> {
 
         let three = sub1
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&three.unwrap().unwrap()).unwrap();
@@ -146,7 +146,7 @@ fn test_workflow_run_serial() -> Result<()> {
 
         let msg = sub2
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&msg.unwrap().unwrap()).unwrap();
@@ -156,13 +156,13 @@ fn test_workflow_run_serial() -> Result<()> {
 
         assert!(sub2
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap()
             .is_some());
         assert!(sub2
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap()
             .is_some());
@@ -179,25 +179,25 @@ fn test_workflow_run_serial() -> Result<()> {
 
         let _ = sub2
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .is_err();
 
         assert!(sub3
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap()
             .is_some());
         assert!(sub2
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap()
             .is_some());
         assert!(sub2
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap()
             .is_some());
@@ -215,24 +215,24 @@ fn test_workflow_run_serial() -> Result<()> {
 
         let _ = sub3
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .is_err();
         assert!(sub4
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap()
             .is_some());
         assert!(sub4
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap()
             .is_some());
         assert!(sub4
             .next()
-            .with_timeout(std::time::Duration::from_millis(25000))
+            .with_timeout(std::time::Duration::from_millis(25_000))
             .await
             .unwrap()
             .is_some());


### PR DESCRIPTION
# Description

This PR implements the following changes:

- [x] Add receipt published and received notifications
- [x] Update receipt sharing log messages
- [x] Add receipt sharing integration test
- [x] Add `remove_db` and `wait_for_socket_connection` test utilities
- [x] Update JSON `peer_id` key to `peerId`

## Link to issue

Implements #131 

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

This PR includes an integration test that checks for gossiped receipts in websocket notifications and logs.
