### PR TITLE
fix: make configuration run without -c (all defaults)

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -6,11 +6,19 @@ passthrough = [
   "RUSTFLAGS",
 ]
 
+# When running `cross` with nix, do this within `nix-shell -p gcc rustup`.
+#
+# Then, run
+#
+# `cross build -p homestar-runtime --target x86_64-unknown-linux-musl`
+# or
+# `cross build -p homestar-runtime --target aarch64-unknown-linux-musl`
+
 [target.x86_64-unknown-linux-musl]
 image = "burntsushi/cross:x86_64-unknown-linux-musl"
 
 [target.aarch64-unknown-linux-musl]
-image = "burntsushi/cross:aarch64-unknown-linux-gnu"
+image = "burntsushi/cross:aarch64-unknown-linux-musl"
 
 [target.x86_64-apple-darwin]
 image = "freeznet/x86_64-apple-darwin-cross:11.3"

--- a/homestar-runtime/src/cli.rs
+++ b/homestar-runtime/src/cli.rs
@@ -19,7 +19,6 @@ pub use error::Error;
 pub(crate) mod show;
 pub(crate) use show::ConsoleTable;
 
-const DEFAULT_SETTINGS_FILE: &str = "./config/settings.toml";
 const DEFAULT_DB_PATH: &str = "homestar.db";
 const TMP_DIR: &str = "/tmp";
 const HELP_TEMPLATE: &str = "{name} {version}
@@ -87,13 +86,12 @@ pub enum Command {
             help = "Database path (SQLite) [optional]"
         )]
         database_url: Option<String>,
-        /// Runtime configuration file (.toml), defaults to ./config/settings.toml.
+        /// Runtime configuration file (.toml).
         #[arg(
             short = 'c',
             long = "config",
             value_hint = clap::ValueHint::FilePath,
             value_name = "CONFIG",
-            default_value = DEFAULT_SETTINGS_FILE,
             help = "Runtime configuration file (.toml) [optional]"
         )]
         runtime_config: Option<PathBuf>,

--- a/homestar-runtime/src/scheduler.rs
+++ b/homestar-runtime/src/scheduler.rs
@@ -171,6 +171,7 @@ impl<'a> TaskScheduler<'a> {
             .into_iter()
             .map(|(_, rsc)| rsc.to_owned())
             .collect();
+
         let fetched = fetch_fn(resources_to_fetch).await?;
 
         match resume {

--- a/homestar-runtime/src/settings.rs
+++ b/homestar-runtime/src/settings.rs
@@ -294,7 +294,7 @@ impl Default for Network {
             rpc_max_connections: 10,
             rpc_port: 3030,
             rpc_server_timeout: Duration::new(120, 0),
-            transport_connection_timeout: Duration::new(20, 0),
+            transport_connection_timeout: Duration::new(60, 0),
             webserver_host: Uri::from_static("127.0.0.1"),
             webserver_port: 1337,
             webserver_timeout: Duration::new(120, 0),

--- a/homestar-runtime/src/workflow/settings.rs
+++ b/homestar-runtime/src/workflow/settings.rs
@@ -18,7 +18,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            retries: 10,
+            retries: 3,
             retry_max_delay: Duration::new(60, 0),
             retry_initial_delay: Duration::from_millis(500),
             p2p_timeout: Duration::new(5, 0),

--- a/homestar-wasm/src/wasmtime/error.rs
+++ b/homestar-wasm/src/wasmtime/error.rs
@@ -40,7 +40,7 @@ pub enum Error {
     #[error(transparent)]
     WasmRuntime(#[from] anyhow::Error),
     /// Failure to find Wasm function for execution.
-    #[error("Wasm function {0} not found")]
+    #[error("Wasm function {0} not found in given Wasm component/resource")]
     WasmFunctionNotFound(String),
     /// [Wat] as Wasm component error.
     ///

--- a/homestar-wasm/src/wasmtime/world.rs
+++ b/homestar-wasm/src/wasmtime/world.rs
@@ -121,7 +121,7 @@ impl<T> Env<T> {
                     },
                     Input::Deferred(await_promise) => {
                         bail!(Error::ResolvePromise(ResolveError::UnresolvedCid(format!(
-                            "deferred task not yet resolved for {}: {}",
+                            "deferred task/instruction not yet resolved or exists for promise: {}: {}",
                             await_promise.result(),
                             await_promise.instruction_cid()
                         ))))


### PR DESCRIPTION
Includes:

- also, add starter functions for default .pem/settings initialization
- error handling around retry, wasms
- ups the transport timeout