### PR TITLE
refactor: Add Gossipsub Message wrapper

### DIFF
--- a/homestar-runtime/src/event_handler/event.rs
+++ b/homestar-runtime/src/event_handler/event.rs
@@ -263,7 +263,6 @@ impl Captured {
         if event_handler.pubsub_enabled {
             match event_handler.swarm.behaviour_mut().gossip_publish(
                 pubsub::RECEIPTS_TOPIC,
-                // TopicMessage::CapturedReceipt(receipt.clone()),
                 TopicMessage::CapturedReceipt(pubsub::Message::new(receipt.clone())),
             ) {
                 Ok(msg_id) => {

--- a/homestar-runtime/src/event_handler/event.rs
+++ b/homestar-runtime/src/event_handler/event.rs
@@ -238,6 +238,7 @@ impl Captured {
     }
 
     #[allow(dead_code)]
+    // TODO rename publish_and_notify
     fn store_and_notify<DB>(
         mut self,
         event_handler: &mut EventHandler<DB>,
@@ -262,7 +263,8 @@ impl Captured {
         if event_handler.pubsub_enabled {
             match event_handler.swarm.behaviour_mut().gossip_publish(
                 pubsub::RECEIPTS_TOPIC,
-                TopicMessage::CapturedReceipt(receipt.clone()),
+                // TopicMessage::CapturedReceipt(receipt.clone()),
+                TopicMessage::CapturedReceipt(pubsub::Message::new(receipt.clone())),
             ) {
                 Ok(msg_id) => {
                     info!(
@@ -392,7 +394,8 @@ impl Replay {
                     .behaviour_mut()
                     .gossip_publish(
                         pubsub::RECEIPTS_TOPIC,
-                        TopicMessage::CapturedReceipt(receipt.clone()),
+                        // TopicMessage::CapturedReceipt(receipt.clone()),
+                        TopicMessage::CapturedReceipt(pubsub::Message::new(receipt.clone())),
                     )
                     .map(|msg_id| {
                          info!(cid=receipt_cid,

--- a/homestar-runtime/src/event_handler/event.rs
+++ b/homestar-runtime/src/event_handler/event.rs
@@ -127,7 +127,7 @@ impl Event {
     {
         match self {
             Event::CapturedReceipt(captured) => {
-                let _ = captured.store_and_notify(event_handler);
+                let _ = captured.publish_and_notify(event_handler);
             }
             Event::Shutdown(tx) => {
                 info!("event_handler server shutting down");
@@ -238,8 +238,7 @@ impl Captured {
     }
 
     #[allow(dead_code)]
-    // TODO rename publish_and_notify
-    fn store_and_notify<DB>(
+    fn publish_and_notify<DB>(
         mut self,
         event_handler: &mut EventHandler<DB>,
     ) -> Result<(Cid, InvocationReceipt<Ipld>)>
@@ -393,7 +392,6 @@ impl Replay {
                     .behaviour_mut()
                     .gossip_publish(
                         pubsub::RECEIPTS_TOPIC,
-                        // TopicMessage::CapturedReceipt(receipt.clone()),
                         TopicMessage::CapturedReceipt(pubsub::Message::new(receipt.clone())),
                     )
                     .map(|msg_id| {
@@ -540,7 +538,7 @@ where
     async fn handle_event(self, event_handler: &mut EventHandler<DB>, ipfs: IpfsCli) {
         match self {
             Event::CapturedReceipt(captured) => {
-                if let Ok((cid, receipt)) = captured.store_and_notify(event_handler) {
+                if let Ok((cid, receipt)) = captured.publish_and_notify(event_handler) {
                     #[cfg(not(feature = "test-utils"))]
                     {
                         // Spawn client call in the background, without awaiting.

--- a/homestar-runtime/src/event_handler/swarm_event.rs
+++ b/homestar-runtime/src/event_handler/swarm_event.rs
@@ -48,6 +48,7 @@ use libp2p::{
 use maplit::btreemap;
 use std::{
     collections::{HashMap, HashSet},
+    convert::Infallible,
     fmt,
 };
 use tracing::{debug, error, info, warn};
@@ -413,13 +414,13 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
                 // let data: Result<pubsub::Message<Receipt>, _> =
                 //     pubsub::Message::try_from(message.data);
                 let foo: Vec<u8> = message.data;
-                let bar: pubsub::Message<Receipt> = foo.try_into().unwrap();
+                //let bar: pubsub::Message<Receipt> = foo.try_into().unwrap();
+                let bar: Result<pubsub::Message<Receipt>, anyhow::Error> = foo.try_into();
 
-                match pubsub::Message::try_from(message.data) {
+                match bar {
                     // TODO: dont fail blindly if we get a non receipt message
                     Ok(msg) => {
-                        let receipt: Result<Receipt, anyhow::Error> =
-                            Receipt::try_from(msg.payload);
+                        let receipt: Result<Receipt, Infallible> = Receipt::try_from(msg.payload);
 
                         if let Ok(receipt) = receipt {
                             info!(

--- a/homestar-runtime/src/event_handler/swarm_event.rs
+++ b/homestar-runtime/src/event_handler/swarm_event.rs
@@ -13,8 +13,11 @@ use crate::{
         Event, Handler, RequestResponseError,
     },
     libp2p::multiaddr::MultiaddrExt,
-    network::swarm::{
-        CapsuleTag, ComposedEvent, PeerDiscoveryInfo, RequestResponseKey, HOMESTAR_PROTOCOL_VER,
+    network::{
+        pubsub,
+        swarm::{
+            CapsuleTag, ComposedEvent, PeerDiscoveryInfo, RequestResponseKey, HOMESTAR_PROTOCOL_VER,
+        },
     },
     receipt::{RECEIPT_TAG, VERSION_KEY},
     workflow,
@@ -403,37 +406,56 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
                 message,
                 propagation_source,
                 message_id,
-            } => match Receipt::try_from(message.data) {
-                // TODO: dont fail blindly if we get a non receipt message
-                Ok(receipt) => {
-                    info!(
-                        peer_id = propagation_source.to_string(),
-                        message_id = message_id.to_string(),
-                        "message received on receipts topic: {receipt}"
-                    );
+                // } => match Receipt::try_from(message.data) {
+            } => {
+                // match pubsub::Message::try_from(message.data) {
 
-                    // Store gossiped receipt.
-                    let _ = event_handler
-                        .db
-                        .conn()
-                        .as_mut()
-                        .map(|conn| Db::store_receipt(receipt.clone(), conn));
+                // let data: Result<pubsub::Message<Receipt>, _> =
+                //     pubsub::Message::try_from(message.data);
+                let foo: Vec<u8> = message.data;
+                let bar: pubsub::Message<Receipt> = foo.try_into().unwrap();
 
-                    #[cfg(feature = "websocket-notify")]
-                    notification::emit_event(
-                        event_handler.ws_evt_sender(),
-                        EventNotificationTyp::SwarmNotification(
-                            SwarmNotification::ReceivedReceiptPubsub,
-                        ),
-                        btreemap! {
-                            "peerId" => propagation_source.to_string(),
-                            "cid" => receipt.cid().to_string(),
-                            "ran" => receipt.ran().to_string()
-                        },
-                    );
+                match pubsub::Message::try_from(message.data) {
+                    // TODO: dont fail blindly if we get a non receipt message
+                    Ok(msg) => {
+                        let receipt: Result<Receipt, anyhow::Error> =
+                            Receipt::try_from(msg.payload);
+
+                        if let Ok(receipt) = receipt {
+                            info!(
+                                peer_id = propagation_source.to_string(),
+                                message_id = message_id.to_string(),
+                                "message received on receipts topic: {receipt}"
+                            );
+
+                            println!("RECEIPT");
+
+                            // Store gossiped receipt.
+                            let _ = event_handler
+                                .db
+                                .conn()
+                                .as_mut()
+                                .map(|conn| Db::store_receipt(receipt.clone(), conn));
+
+                            #[cfg(feature = "websocket-notify")]
+                            notification::emit_event(
+                                event_handler.ws_evt_sender(),
+                                EventNotificationTyp::SwarmNotification(
+                                    SwarmNotification::ReceivedReceiptPubsub,
+                                ),
+                                btreemap! {
+                                    "peerId" => propagation_source.to_string(),
+                                    "cid" => receipt.cid().to_string(),
+                                    "ran" => receipt.ran().to_string()
+                                },
+                            );
+                        } else {
+                            //
+                        }
+                    }
+                    Err(err) => info!(err=?err, "cannot handle incoming gossipsub message"),
                 }
-                Err(err) => info!(err=?err, "cannot handle incoming gossipsub message"),
-            },
+            }
             gossipsub::Event::Subscribed { peer_id, topic } => {
                 debug!(
                     peer_id = peer_id.to_string(),

--- a/homestar-runtime/src/network/pubsub.rs
+++ b/homestar-runtime/src/network/pubsub.rs
@@ -5,13 +5,16 @@
 use crate::settings;
 use anyhow::Result;
 use libp2p::{
-    gossipsub::{self, ConfigBuilder, Message, MessageAuthenticity, MessageId, ValidationMode},
+    gossipsub::{self, ConfigBuilder, MessageAuthenticity, MessageId, ValidationMode},
     identity::Keypair,
 };
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
 };
+
+pub(crate) mod message;
+pub(crate) use message::Message;
 
 /// [Receipt]-related topic for pub(gossip)sub.
 ///
@@ -23,7 +26,7 @@ pub(crate) const RECEIPTS_TOPIC: &str = "receipts";
 /// [gossipsub]: libp2p::gossipsub
 pub(crate) fn new(keypair: Keypair, settings: &settings::Node) -> Result<gossipsub::Behaviour> {
     // To content-address message, we can take the hash of message and use it as an ID.
-    let message_id_fn = |message: &Message| {
+    let message_id_fn = |message: &gossipsub::Message| {
         let mut s = DefaultHasher::new();
         message.data.hash(&mut s);
         MessageId::from(s.finish().to_string())

--- a/homestar-runtime/src/network/pubsub/message.rs
+++ b/homestar-runtime/src/network/pubsub/message.rs
@@ -1,0 +1,151 @@
+use anyhow::anyhow;
+use anyhow::Result;
+use homestar_core::workflow::Nonce;
+use libipld::{self, cbor::DagCborCodec, prelude::Codec, serde::from_ipld, Ipld};
+use std::collections::BTreeMap;
+
+#[derive(Debug)]
+pub(crate) struct Message<T> {
+    header: Header,
+    payload: T,
+}
+
+const HEADER_KEY: &str = "header";
+const PAYLOAD_KEY: &str = "payload";
+const NONCE_KEY: &str = "nonce";
+
+impl<T> Message<T> {
+    pub(crate) fn new(payload: T) -> Self {
+        let header = Header {
+            nonce: Nonce::generate(),
+        };
+
+        Self { header, payload }
+    }
+}
+
+impl<T> TryFrom<Message<T>> for Vec<u8>
+where
+    Ipld: From<Message<T>>,
+{
+    type Error = anyhow::Error;
+
+    fn try_from(message: Message<T>) -> Result<Self, Self::Error> {
+        let message_ipld = Ipld::from(message);
+        DagCborCodec.encode(&message_ipld)
+    }
+}
+
+impl<T> TryFrom<Vec<u8>> for Message<T>
+where
+    Ipld: TryInto<Message<T>>,
+    T: TryFrom<Vec<u8>>,
+{
+    type Error = anyhow::Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let ipld: Ipld = DagCborCodec.decode(&bytes)?;
+        ipld.try_into()
+            .map_err(|_| anyhow!("Could not convert IPLD to pubsub message."))
+    }
+}
+
+impl From<Message<Ipld>> for Ipld {
+    fn from(message: Message<Ipld>) -> Self {
+        From::from(&message)
+    }
+}
+
+impl From<&Message<Ipld>> for Ipld {
+    fn from(message: &Message<Ipld>) -> Self {
+        Ipld::Map(BTreeMap::from([
+            (HEADER_KEY.into(), message.header.to_owned().into()),
+            (PAYLOAD_KEY.into(), message.payload.to_owned().into()),
+        ]))
+    }
+}
+
+impl<'a, T> TryFrom<Ipld> for Message<T>
+where
+    T: From<&'a Ipld>,
+    Ipld: From<T>,
+{
+    type Error = anyhow::Error;
+
+    fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
+        let map = from_ipld::<BTreeMap<String, Ipld>>(ipld)?;
+
+        let header = map
+            .get(HEADER_KEY)
+            .ok_or_else(|| anyhow!("missing {HEADER_KEY}"))?
+            .try_into()?;
+
+        let payload = map
+            .get(PAYLOAD_KEY)
+            .ok_or_else(|| anyhow!("missing {PAYLOAD_KEY}"))?
+            .try_into()?;
+
+        Ok(Message { header, payload })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Header {
+    nonce: Nonce,
+}
+
+impl From<&Header> for Ipld {
+    fn from(header: &Header) -> Self {
+        Ipld::Map(BTreeMap::from([(
+            NONCE_KEY.into(),
+            header.nonce.to_owned().into(),
+        )]))
+    }
+}
+
+impl From<Header> for Ipld {
+    fn from(header: Header) -> Self {
+        From::from(&header)
+    }
+}
+
+impl TryFrom<&Ipld> for Header {
+    type Error = anyhow::Error;
+
+    fn try_from(ipld: &Ipld) -> Result<Self, Self::Error> {
+        TryFrom::try_from(ipld.to_owned())
+    }
+}
+
+impl TryFrom<Ipld> for Header {
+    type Error = anyhow::Error;
+
+    fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
+        let map = from_ipld::<BTreeMap<String, Ipld>>(ipld)?;
+
+        let nonce = map
+            .get(NONCE_KEY)
+            .ok_or_else(|| anyhow!("Missing {NONCE_KEY}"))?
+            .try_into()?;
+
+        Ok(Header { nonce })
+    }
+}
+
+impl TryFrom<Header> for Vec<u8> {
+    type Error = anyhow::Error;
+
+    fn try_from(header: Header) -> Result<Self, Self::Error> {
+        let header_ipld = Ipld::from(header);
+        DagCborCodec.encode(&header_ipld)
+    }
+}
+
+impl TryFrom<Vec<u8>> for Header {
+    type Error = anyhow::Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let ipld: Ipld = DagCborCodec.decode(&bytes)?;
+        ipld.try_into()
+    }
+}

--- a/homestar-runtime/src/network/pubsub/message.rs
+++ b/homestar-runtime/src/network/pubsub/message.rs
@@ -3,15 +3,15 @@ use homestar_core::workflow::Nonce;
 use libipld::{self, cbor::DagCborCodec, prelude::Codec, serde::from_ipld, Ipld};
 use std::collections::BTreeMap;
 
-#[derive(Debug)]
-pub(crate) struct Message<T> {
-    header: Header,
-    payload: T,
-}
-
 const HEADER_KEY: &str = "header";
 const PAYLOAD_KEY: &str = "payload";
 const NONCE_KEY: &str = "nonce";
+
+#[derive(Debug)]
+pub(crate) struct Message<T> {
+    pub(crate) header: Header,
+    pub(crate) payload: T,
+}
 
 impl<T> Message<T> {
     pub(crate) fn new(payload: T) -> Self {

--- a/homestar-runtime/src/network/pubsub/message.rs
+++ b/homestar-runtime/src/network/pubsub/message.rs
@@ -37,8 +37,7 @@ where
 
 impl<T> TryFrom<Vec<u8>> for Message<T>
 where
-    Ipld: TryInto<Message<T>>,
-    T: TryFrom<Vec<u8>>,
+    T: TryFrom<Ipld, Error = anyhow::Error>,
 {
     type Error = anyhow::Error;
 
@@ -48,16 +47,6 @@ where
             .map_err(|_| anyhow!("Could not convert IPLD to pubsub message."))
     }
 }
-
-// impl TryFrom<Vec<u8>> for Message<crate::Receipt> {
-//     type Error = anyhow::Error;
-
-//     fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-//         let ipld: Ipld = DagCborCodec.decode(&bytes)?;
-//         ipld.try_into()
-//             .map_err(|_| anyhow!("Could not convert IPLD to pubsub message."))
-//     }
-// }
 
 impl<T> From<Message<T>> for Ipld
 where
@@ -73,7 +62,7 @@ where
 
 impl<T> TryFrom<Ipld> for Message<T>
 where
-    T: From<Ipld>,
+    T: TryFrom<Ipld, Error = anyhow::Error>,
 {
     type Error = anyhow::Error;
 
@@ -96,27 +85,27 @@ where
     }
 }
 
-impl TryFrom<Ipld> for Message<crate::Receipt> {
-    type Error = anyhow::Error;
+// impl TryFrom<Ipld> for Message<crate::Receipt> {
+//     type Error = anyhow::Error;
 
-    fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
-        let map = from_ipld::<BTreeMap<String, Ipld>>(ipld)?;
+//     fn try_from(ipld: Ipld) -> Result<Self, Self::Error> {
+//         let map = from_ipld::<BTreeMap<String, Ipld>>(ipld)?;
 
-        let header = map
-            .get(HEADER_KEY)
-            .ok_or_else(|| anyhow!("missing {HEADER_KEY}"))?
-            .to_owned()
-            .try_into()?;
+//         let header = map
+//             .get(HEADER_KEY)
+//             .ok_or_else(|| anyhow!("missing {HEADER_KEY}"))?
+//             .to_owned()
+//             .try_into()?;
 
-        let payload = map
-            .get(PAYLOAD_KEY)
-            .ok_or_else(|| anyhow!("missing {PAYLOAD_KEY}"))?
-            .to_owned()
-            .try_into()?;
+//         let payload = map
+//             .get(PAYLOAD_KEY)
+//             .ok_or_else(|| anyhow!("missing {PAYLOAD_KEY}"))?
+//             .to_owned()
+//             .try_into()?;
 
-        Ok(Message { header, payload })
-    }
-}
+//         Ok(Message { header, payload })
+//     }
+// }
 
 #[derive(Clone, Debug)]
 pub(crate) struct Header {

--- a/homestar-runtime/src/network/swarm.rs
+++ b/homestar-runtime/src/network/swarm.rs
@@ -270,7 +270,8 @@ pub(crate) enum ComposedEvent {
 #[derive(Debug)]
 pub(crate) enum TopicMessage {
     /// Receipt topic, wrapping [Receipt].
-    CapturedReceipt(Receipt),
+    CapturedReceipt(pubsub::Message<Receipt>),
+    // CapturedReceipt(Receipt),
 }
 
 /// Custom behaviours for [Swarm].
@@ -316,8 +317,11 @@ impl ComposedBehaviour {
         if let Some(gossipsub) = self.gossipsub.as_mut() {
             let id_topic = gossipsub::IdentTopic::new(topic);
             // Make this a match once we have other topics.
-            let TopicMessage::CapturedReceipt(receipt) = msg;
-            let msg_bytes: Vec<u8> = receipt.try_into()?;
+            // let TopicMessage::CapturedReceipt(receipt) = msg;
+            // let msg_bytes: Vec<u8> = receipt.try_into()?;
+            let TopicMessage::CapturedReceipt(message) = msg;
+            let msg_bytes: Vec<u8> = message.try_into()?;
+
             if gossipsub
                 .mesh_peers(&TopicHash::from_raw(topic))
                 .peekable()

--- a/homestar-runtime/src/network/swarm.rs
+++ b/homestar-runtime/src/network/swarm.rs
@@ -271,7 +271,6 @@ pub(crate) enum ComposedEvent {
 pub(crate) enum TopicMessage {
     /// Receipt topic, wrapping [Receipt].
     CapturedReceipt(pubsub::Message<Receipt>),
-    // CapturedReceipt(Receipt),
 }
 
 /// Custom behaviours for [Swarm].
@@ -317,8 +316,6 @@ impl ComposedBehaviour {
         if let Some(gossipsub) = self.gossipsub.as_mut() {
             let id_topic = gossipsub::IdentTopic::new(topic);
             // Make this a match once we have other topics.
-            // let TopicMessage::CapturedReceipt(receipt) = msg;
-            // let msg_bytes: Vec<u8> = receipt.try_into()?;
             let TopicMessage::CapturedReceipt(message) = msg;
             let msg_bytes: Vec<u8> = message.try_into()?;
 


### PR DESCRIPTION
# Description

This PR implements the following changes:

- [x] Add gosssipsub message wrapper
- [x] Rename `store_and_notify` to `publish_and_notify`

The message wrapper includes a header with a nonce to force the gossip of duplicate receipts. We will likely expand on the header in future work and make the nonce optional.

## Link to issue

Implements #421.

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

We've added a unit test to roundtrip a gossiped message to bytes and back again. We also have a gossip notifications integration test to confirm messages are still sent.
