### PR TITLE
chore: Remove databases after test runs

### DIFF
--- a/homestar-runtime/tests/cli.rs
+++ b/homestar-runtime/tests/cli.rs
@@ -111,12 +111,13 @@ fn test_server_not_running_serial() -> Result<()> {
 #[test]
 #[file_serial]
 fn test_server_serial() -> Result<()> {
+    const DB: &str = "test_server_serial.db";
     let _ = stop_homestar();
 
     Command::new(BIN.as_os_str())
         .arg("start")
         .arg("-db")
-        .arg("homestar.db")
+        .arg(DB)
         .assert()
         .failure();
 
@@ -125,7 +126,7 @@ fn test_server_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_v6.toml")
         .arg("--db")
-        .arg("homestar.db")
+        .arg(DB)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -163,6 +164,7 @@ fn test_server_serial() -> Result<()> {
 
     let _ = kill_homestar(homestar_proc, None);
     let _ = stop_homestar();
+    remove_db(DB);
 
     Ok(())
 }
@@ -170,7 +172,7 @@ fn test_server_serial() -> Result<()> {
 #[test]
 #[file_serial]
 fn test_workflow_run_serial() -> Result<()> {
-    const DB: &str = "homestar_test_cli_test_workflow_run_serial.db";
+    const DB: &str = "test_workflow_run_serial.db";
 
     let _ = stop_homestar();
 
@@ -230,6 +232,7 @@ fn test_workflow_run_serial() -> Result<()> {
 #[file_serial]
 #[cfg(not(windows))]
 fn test_daemon_serial() -> Result<()> {
+    const DB: &str = "test_daemon_serial.db";
     let _ = stop_homestar();
 
     Command::new(BIN.as_os_str())
@@ -237,7 +240,7 @@ fn test_daemon_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_v4.toml")
         .arg("-d")
-        .env("DATABASE_URL", "homestar.db")
+        .env("DATABASE_URL", DB)
         .stdout(Stdio::piped())
         .assert()
         .success();
@@ -259,6 +262,7 @@ fn test_daemon_serial() -> Result<()> {
 
     let _ = stop_homestar();
     let _ = kill_homestar_daemon();
+    remove_db(DB);
 
     Ok(())
 }
@@ -266,6 +270,7 @@ fn test_daemon_serial() -> Result<()> {
 #[test]
 #[file_serial]
 fn test_server_v4_serial() -> Result<()> {
+    const DB: &str = "test_server_v4_serial.db";
     let _ = stop_homestar();
 
     let homestar_proc = Command::new(BIN.as_os_str())
@@ -273,7 +278,7 @@ fn test_server_v4_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_v4.toml")
         .arg("--db")
-        .arg("homestar.db")
+        .arg(DB)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -297,6 +302,7 @@ fn test_server_v4_serial() -> Result<()> {
     let _ = Command::new(BIN.as_os_str()).arg("stop").output();
     let _ = kill_homestar(homestar_proc, None);
     let _ = stop_homestar();
+    remove_db(DB);
 
     Ok(())
 }

--- a/homestar-runtime/tests/metrics.rs
+++ b/homestar-runtime/tests/metrics.rs
@@ -16,6 +16,8 @@ const METRICS_URL: &str = "http://localhost:4020";
 #[test]
 #[file_serial]
 fn test_metrics_serial() -> Result<()> {
+    use crate::utils::remove_db;
+
     fn sample_metrics() -> Option<prometheus_parse::Value> {
         let body = retry(
             Exponential::from_millis(500).take(20),
@@ -41,6 +43,7 @@ fn test_metrics_serial() -> Result<()> {
             .map(|sample| sample.value.to_owned())
     }
 
+    const DB: &str = "test_metrics_serial.db";
     let _ = stop_homestar();
 
     let mut homestar_proc = Command::new(BIN.as_os_str())
@@ -48,7 +51,7 @@ fn test_metrics_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_metrics.toml")
         .arg("--db")
-        .arg("homestar.db")
+        .arg(DB)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -86,6 +89,7 @@ fn test_metrics_serial() -> Result<()> {
 
     let _ = kill_homestar(homestar_proc, None);
     let _ = stop_homestar();
+    remove_db(DB);
 
     Ok(())
 }

--- a/homestar-runtime/tests/network.rs
+++ b/homestar-runtime/tests/network.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    check_lines_for, count_lines_where, kill_homestar, retrieve_output, stop_homestar,
+    check_lines_for, count_lines_where, kill_homestar, remove_db, retrieve_output, stop_homestar,
     wait_for_socket_connection, wait_for_socket_connection_v6, BIN_NAME,
 };
 use anyhow::Result;
@@ -23,6 +23,7 @@ static BIN: Lazy<PathBuf> = Lazy::new(|| assert_cmd::cargo::cargo_bin(BIN_NAME))
 #[test]
 #[file_serial]
 fn test_libp2p_generates_peer_id_serial() -> Result<()> {
+    const DB: &str = "test_libp2p_generates_peer_id_serial.db";
     let _ = stop_homestar();
 
     let homestar_proc = Command::new(BIN.as_os_str())
@@ -30,7 +31,7 @@ fn test_libp2p_generates_peer_id_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_network1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -52,12 +53,15 @@ fn test_libp2p_generates_peer_id_serial() -> Result<()> {
 
     assert!(logs_expected);
 
+    remove_db(DB);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_libp2p_listens_on_address_serial() -> Result<()> {
+    const DB: &str = "test_libp2p_listens_on_address_serial.db";
     let _ = stop_homestar();
 
     let homestar_proc = Command::new(BIN.as_os_str())
@@ -65,7 +69,7 @@ fn test_libp2p_listens_on_address_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_network1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -88,12 +92,15 @@ fn test_libp2p_listens_on_address_serial() -> Result<()> {
 
     assert!(logs_expected);
 
+    remove_db(DB);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_rpc_listens_on_address_serial() -> Result<()> {
+    const DB: &str = "test_rpc_listens_on_address_serial.db";
     let _ = stop_homestar();
 
     let homestar_proc = Command::new(BIN.as_os_str())
@@ -101,7 +108,7 @@ fn test_rpc_listens_on_address_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_network1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -117,12 +124,15 @@ fn test_rpc_listens_on_address_serial() -> Result<()> {
 
     assert!(logs_expected);
 
+    remove_db(DB);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_websocket_listens_on_address_serial() -> Result<()> {
+    const DB: &str = "test_websocket_listens_on_address_serial.db";
     let _ = stop_homestar();
 
     let homestar_proc = Command::new(BIN.as_os_str())
@@ -130,7 +140,7 @@ fn test_websocket_listens_on_address_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_network1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -146,12 +156,16 @@ fn test_websocket_listens_on_address_serial() -> Result<()> {
 
     assert!(logs_expected);
 
+    remove_db(DB);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_libp2p_connect_known_peers_serial() -> Result<()> {
+    const DB1: &str = "test_libp2p_connect_known_peers_serial1.db";
+    const DB2: &str = "test_libp2p_connect_known_peers_serial2.db";
     let _ = stop_homestar();
 
     // Start two nodes configured to listen at 127.0.0.1 each with their own port.
@@ -165,7 +179,7 @@ fn test_libp2p_connect_known_peers_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_network1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -184,7 +198,7 @@ fn test_libp2p_connect_known_peers_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_network2.toml")
         .arg("--db")
-        .arg("homestar2.db")
+        .arg(DB2)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -264,12 +278,17 @@ fn test_libp2p_connect_known_peers_serial() -> Result<()> {
     assert!(one_in_dht_routing_table);
     assert!(two_connected_to_one);
 
+    remove_db(DB1);
+    remove_db(DB2);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_libp2p_connect_after_mdns_discovery_serial() -> Result<()> {
+    const DB1: &str = "test_libp2p_connect_after_mdns_discovery_serial1.db";
+    const DB2: &str = "test_libp2p_connect_after_mdns_discovery_serial2.db";
     let _ = stop_homestar();
 
     // Start two nodes each configured to listen at 0.0.0.0 with no known peers.
@@ -283,7 +302,7 @@ fn test_libp2p_connect_after_mdns_discovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_mdns1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -302,7 +321,7 @@ fn test_libp2p_connect_after_mdns_discovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_mdns2.toml")
         .arg("--db")
-        .arg("homestar2.db")
+        .arg(DB2)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -382,12 +401,18 @@ fn test_libp2p_connect_after_mdns_discovery_serial() -> Result<()> {
     assert!(one_addded_to_dht);
     assert!(one_in_dht_routing_table);
 
+    remove_db(DB1);
+    remove_db(DB2);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_libp2p_connect_rendezvous_discovery_serial() -> Result<()> {
+    const DB1: &str = "test_libp2p_connect_rendezvous_discovery_serial1.db";
+    const DB2: &str = "test_libp2p_connect_rendezvous_discovery_serial2.db";
+    const DB3: &str = "test_libp2p_connect_rendezvous_discovery_serial3.db";
     let _ = stop_homestar();
 
     // Start a rendezvous server
@@ -400,7 +425,7 @@ fn test_libp2p_connect_rendezvous_discovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -420,7 +445,7 @@ fn test_libp2p_connect_rendezvous_discovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous2.toml")
         .arg("--db")
-        .arg("homestar2.db")
+        .arg(DB2)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -444,7 +469,7 @@ fn test_libp2p_connect_rendezvous_discovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous3.toml")
         .arg("--db")
-        .arg("homestar3.db")
+        .arg(DB3)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -515,12 +540,18 @@ fn test_libp2p_connect_rendezvous_discovery_serial() -> Result<()> {
     assert!(one_in_dht_routing_table);
     assert!(two_connected_to_one);
 
+    remove_db(DB1);
+    remove_db(DB2);
+    remove_db(DB3);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_libp2p_disconnect_mdns_discovery_serial() -> Result<()> {
+    const DB1: &str = "test_libp2p_disconnect_mdns_discovery_serial1.db";
+    const DB2: &str = "test_libp2p_disconnect_mdns_discovery_serial2.db";
     let _ = stop_homestar();
 
     // Start two nodes each configured to listen at 0.0.0.0 with no known peers.
@@ -534,7 +565,7 @@ fn test_libp2p_disconnect_mdns_discovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_mdns1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -553,7 +584,7 @@ fn test_libp2p_disconnect_mdns_discovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_mdns2.toml")
         .arg("--db")
-        .arg("homestar2.db")
+        .arg(DB2)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -593,12 +624,17 @@ fn test_libp2p_disconnect_mdns_discovery_serial() -> Result<()> {
     assert!(two_disconnected_from_one);
     assert!(two_removed_from_dht_table);
 
+    remove_db(DB1);
+    remove_db(DB2);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_libp2p_disconnect_known_peers_serial() -> Result<()> {
+    const DB1: &str = "test_libp2p_disconnect_known_peers_serial1.db";
+    const DB2: &str = "test_libp2p_disconnect_known_peers_serial2.db";
     let _ = stop_homestar();
 
     // Start two nodes configured to listen at 127.0.0.1 each with their own port.
@@ -612,7 +648,7 @@ fn test_libp2p_disconnect_known_peers_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_network1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -631,7 +667,7 @@ fn test_libp2p_disconnect_known_peers_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_network2.toml")
         .arg("--db")
-        .arg("homestar2.db")
+        .arg(DB2)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -671,12 +707,18 @@ fn test_libp2p_disconnect_known_peers_serial() -> Result<()> {
     assert!(two_disconnected_from_one);
     assert!(!two_removed_from_dht_table);
 
+    remove_db(DB1);
+    remove_db(DB2);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_libp2p_disconnect_rendezvous_discovery_serial() -> Result<()> {
+    const DB1: &str = "test_libp2p_disconnect_rendezvous_discovery_serial1.db";
+    const DB2: &str = "test_libp2p_disconnect_rendezvous_discovery_serial2.db";
+    const DB3: &str = "test_libp2p_disconnect_rendezvous_discovery_serial3.db";
     let _ = stop_homestar();
 
     // Start a rendezvous server
@@ -689,7 +731,7 @@ fn test_libp2p_disconnect_rendezvous_discovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -709,7 +751,7 @@ fn test_libp2p_disconnect_rendezvous_discovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous2.toml")
         .arg("--db")
-        .arg("homestar2.db")
+        .arg(DB2)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -733,7 +775,7 @@ fn test_libp2p_disconnect_rendezvous_discovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous3.toml")
         .arg("--db")
-        .arg("homestar3.db")
+        .arg(DB3)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -774,12 +816,18 @@ fn test_libp2p_disconnect_rendezvous_discovery_serial() -> Result<()> {
     assert!(two_disconnected_from_one);
     assert!(two_removed_from_dht_table);
 
+    remove_db(DB1);
+    remove_db(DB2);
+    remove_db(DB3);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_libp2p_rendezvous_renew_registration_serial() -> Result<()> {
+    const DB1: &str = "test_libp2p_rendezvous_renew_registration_serial1.db";
+    const DB2: &str = "test_libp2p_rendezvous_renew_registration_serial2.db";
     let _ = stop_homestar();
 
     // Start a rendezvous server
@@ -792,7 +840,7 @@ fn test_libp2p_rendezvous_renew_registration_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -812,7 +860,7 @@ fn test_libp2p_rendezvous_renew_registration_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous4.toml")
         .arg("--db")
-        .arg("homestar4.db")
+        .arg(DB2)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -851,12 +899,17 @@ fn test_libp2p_rendezvous_renew_registration_serial() -> Result<()> {
     assert!(server_registration_count > 1);
     assert!(client_registration_count > 1);
 
+    remove_db(DB1);
+    remove_db(DB2);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_libp2p_rendezvous_rediscovery_serial() -> Result<()> {
+    const DB1: &str = "test_libp2p_rendezvous_rediscovery_serial1.db";
+    const DB2: &str = "test_libp2p_rendezvous_rediscovery_serial2.db";
     let _ = stop_homestar();
 
     // Start a rendezvous server
@@ -869,7 +922,7 @@ fn test_libp2p_rendezvous_rediscovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -889,7 +942,7 @@ fn test_libp2p_rendezvous_rediscovery_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous5.toml")
         .arg("--db")
-        .arg("homestar5.db")
+        .arg(DB2)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -928,12 +981,18 @@ fn test_libp2p_rendezvous_rediscovery_serial() -> Result<()> {
     assert!(server_discovery_count > 1);
     assert!(client_discovery_count > 1);
 
+    remove_db(DB1);
+    remove_db(DB2);
+
     Ok(())
 }
 
 #[test]
 #[file_serial]
 fn test_libp2p_rendezvous_rediscover_on_expiration_serial() -> Result<()> {
+    const DB1: &str = "test_libp2p_rendezvous_rediscover_on_expiration_serial1.db";
+    const DB2: &str = "test_libp2p_rendezvous_rediscover_on_expiration_serial2.db";
+    const DB3: &str = "test_libp2p_rendezvous_rediscover_on_expiration_serial3.db";
     let _ = stop_homestar();
 
     // Start a rendezvous server
@@ -946,7 +1005,7 @@ fn test_libp2p_rendezvous_rediscover_on_expiration_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -966,7 +1025,7 @@ fn test_libp2p_rendezvous_rediscover_on_expiration_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous6.toml")
         .arg("--db")
-        .arg("homestar6.db")
+        .arg(DB2)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -993,7 +1052,7 @@ fn test_libp2p_rendezvous_rediscover_on_expiration_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_rendezvous3.toml")
         .arg("--db")
-        .arg("homestar3.db")
+        .arg(DB3)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -1032,6 +1091,10 @@ fn test_libp2p_rendezvous_rediscover_on_expiration_serial() -> Result<()> {
 
     assert!(server_discovery_count > 1);
     assert!(client_discovery_count > 1);
+
+    remove_db(DB1);
+    remove_db(DB2);
+    remove_db(DB3);
 
     Ok(())
 }

--- a/homestar-runtime/tests/network/notification.rs
+++ b/homestar-runtime/tests/network/notification.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    kill_homestar, stop_homestar, wait_for_socket_connection, TimeoutFutureExt, BIN_NAME,
+    kill_homestar, remove_db, stop_homestar, wait_for_socket_connection, TimeoutFutureExt, BIN_NAME,
 };
 use anyhow::Result;
 use jsonrpsee::{
@@ -23,6 +23,8 @@ const UNSUBSCRIBE_NETWORK_EVENTS_ENDPOINT: &str = "unsubscribe_network_events";
 #[test]
 #[file_serial]
 fn test_connection_notifications_serial() -> Result<()> {
+    const DB1: &str = "test_connection_notifications_serial1.db";
+    const DB2: &str = "test_connection_notifications_serial2.db";
     let _ = stop_homestar();
 
     let homestar_proc1 = Command::new(BIN.as_os_str())
@@ -34,7 +36,7 @@ fn test_connection_notifications_serial() -> Result<()> {
         .arg("-c")
         .arg("tests/fixtures/test_notification1.toml")
         .arg("--db")
-        .arg("homestar1.db")
+        .arg(DB1)
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
@@ -73,7 +75,7 @@ fn test_connection_notifications_serial() -> Result<()> {
             .arg("-c")
             .arg("tests/fixtures/test_notification2.toml")
             .arg("--db")
-            .arg("homestar2.db")
+            .arg(DB2)
             .stdout(Stdio::piped())
             .spawn()
             .unwrap();
@@ -109,6 +111,8 @@ fn test_connection_notifications_serial() -> Result<()> {
         }
 
         let _ = kill_homestar(homestar_proc1, None);
+        remove_db(DB1);
+        remove_db(DB2);
     });
 
     Ok(())


### PR DESCRIPTION
# Description

This PR implements the following changes:

- [x] Remove temporary databases after test runs

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

The tests should pass and leave no databases behind.
