### PR TITLE
chore: send_async where possible

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -15,8 +15,8 @@ on:
     types: [published]
 
   # for debugging
-  pull_request:
-    branches: [ '**' ]
+  # pull_request:
+  #   branches: [ '**' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/homestar-runtime/src/event_handler.rs
+++ b/homestar-runtime/src/event_handler.rs
@@ -32,7 +32,7 @@ pub(crate) use cache::{setup_cache, CacheValue};
 pub(crate) use error::RequestResponseError;
 pub(crate) use event::Event;
 
-type P2PSender = channel::AsyncBoundedChannelSender<ResponseEvent>;
+type P2PSender = channel::AsyncChannelSender<ResponseEvent>;
 
 /// Handler trait for [EventHandler] events.
 #[async_trait]
@@ -57,8 +57,8 @@ pub(crate) struct EventHandler<DB: Database> {
     db: DB,
     swarm: Swarm<ComposedBehaviour>,
     cache: Arc<Cache<String, CacheValue>>,
-    sender: Arc<channel::AsyncBoundedChannelSender<Event>>,
-    receiver: channel::AsyncBoundedChannelReceiver<Event>,
+    sender: Arc<channel::AsyncChannelSender<Event>>,
+    receiver: channel::AsyncChannelReceiver<Event>,
     query_senders: FnvHashMap<QueryId, (RequestResponseKey, Option<P2PSender>)>,
     connections: Connections,
     request_response_senders: FnvHashMap<RequestId, (RequestResponseKey, P2PSender)>,
@@ -82,8 +82,8 @@ pub(crate) struct EventHandler<DB: Database> {
     db: DB,
     swarm: Swarm<ComposedBehaviour>,
     cache: Arc<Cache<String, CacheValue>>,
-    sender: Arc<channel::AsyncBoundedChannelSender<Event>>,
-    receiver: channel::AsyncBoundedChannelReceiver<Event>,
+    sender: Arc<channel::AsyncChannelSender<Event>>,
+    receiver: channel::AsyncChannelReceiver<Event>,
     query_senders: FnvHashMap<QueryId, (RequestResponseKey, Option<P2PSender>)>,
     connections: Connections,
     request_response_senders: FnvHashMap<RequestId, (RequestResponseKey, P2PSender)>,
@@ -116,10 +116,10 @@ where
     fn setup_channel(
         settings: &settings::Node,
     ) -> (
-        channel::AsyncBoundedChannelSender<Event>,
-        channel::AsyncBoundedChannelReceiver<Event>,
+        channel::AsyncChannelSender<Event>,
+        channel::AsyncChannelReceiver<Event>,
     ) {
-        channel::AsyncBoundedChannel::with(settings.network.events_buffer_len)
+        channel::AsyncChannel::with(settings.network.events_buffer_len)
     }
 
     /// Create an [EventHandler] with channel sender/receiver defaults.
@@ -202,7 +202,7 @@ where
     pub(crate) async fn shutdown(&mut self) {}
 
     /// Get a [Arc]'ed copy of the [EventHandler] channel sender.
-    pub(crate) fn sender(&self) -> Arc<channel::AsyncBoundedChannelSender<Event>> {
+    pub(crate) fn sender(&self) -> Arc<channel::AsyncChannelSender<Event>> {
         self.sender.clone()
     }
 

--- a/homestar-runtime/src/event_handler/cache.rs
+++ b/homestar-runtime/src/event_handler/cache.rs
@@ -49,7 +49,7 @@ pub(crate) enum DispatchEvent {
 }
 
 pub(crate) fn setup_cache(
-    sender: Arc<channel::AsyncBoundedChannelSender<Event>>,
+    sender: Arc<channel::AsyncChannelSender<Event>>,
 ) -> Cache<String, CacheValue> {
     let eviction_listener = move |_key: Arc<String>, val: CacheValue, cause: RemovalCause| {
         let tx = Arc::clone(&sender);

--- a/homestar-runtime/src/event_handler/channel.rs
+++ b/homestar-runtime/src/event_handler/channel.rs
@@ -12,21 +12,21 @@ pub type BoundedChannelReceiver<T> = channel::Receiver<T>;
 /// A bounded [crossbeam::channel] with a sender and receiver.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
-pub struct BoundedChannel<T> {
+pub struct Channel<T> {
     /// Sender for the channel.
     tx: channel::Sender<T>,
     /// REceiver for the channel.
     rx: channel::Receiver<T>,
 }
 
-impl<T> BoundedChannel<T> {
-    /// Create a new [BoundedChannel] with a given capacity.
+impl<T> Channel<T> {
+    /// Create a new [Channel] with a given capacity.
     pub fn with(capacity: usize) -> (BoundedChannelSender<T>, BoundedChannelReceiver<T>) {
         let (tx, rx) = channel::bounded(capacity);
         (tx, rx)
     }
 
-    /// Create a oneshot (1) [BoundedChannel].
+    /// Create a oneshot (1) [Channel].
     pub fn oneshot() -> (BoundedChannelSender<T>, BoundedChannelReceiver<T>) {
         let (tx, rx) = channel::bounded(1);
         (tx, rx)
@@ -34,30 +34,36 @@ impl<T> BoundedChannel<T> {
 }
 
 /// [flume::Sender] for a bounded [flume::bounded] channel.
-pub type AsyncBoundedChannelSender<T> = flume::Sender<T>;
+pub type AsyncChannelSender<T> = flume::Sender<T>;
 
 /// [flume::Receiver] for a bounded [flume::bounded] channel.
-pub type AsyncBoundedChannelReceiver<T> = flume::Receiver<T>;
+pub type AsyncChannelReceiver<T> = flume::Receiver<T>;
 
 /// A bounded [flume] channel with sender and receiver.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
-pub struct AsyncBoundedChannel<T> {
+pub struct AsyncChannel<T> {
     /// Sender for the channel.
     tx: flume::Sender<T>,
     /// REceiver for the channel.
     rx: flume::Receiver<T>,
 }
 
-impl<T> AsyncBoundedChannel<T> {
-    /// Create a new [AsyncBoundedChannel] with a given capacity.
-    pub fn with(capacity: usize) -> (AsyncBoundedChannelSender<T>, AsyncBoundedChannelReceiver<T>) {
+impl<T> AsyncChannel<T> {
+    /// Create a new [AsyncChannel] with a given capacity.
+    pub fn with(capacity: usize) -> (AsyncChannelSender<T>, AsyncChannelReceiver<T>) {
         let (tx, rx) = flume::bounded(capacity);
         (tx, rx)
     }
 
-    /// Create a oneshot (1) [BoundedChannel].
-    pub fn oneshot() -> (AsyncBoundedChannelSender<T>, AsyncBoundedChannelReceiver<T>) {
+    /// Create an unbounded [AsyncChannel].
+    pub fn unbounded() -> (AsyncChannelSender<T>, AsyncChannelReceiver<T>) {
+        let (tx, rx) = flume::unbounded();
+        (tx, rx)
+    }
+
+    /// Create a oneshot (1) [Channel].
+    pub fn oneshot() -> (AsyncChannelSender<T>, AsyncChannelReceiver<T>) {
         let (tx, rx) = flume::bounded(1);
         (tx, rx)
     }

--- a/homestar-runtime/src/event_handler/swarm_event.rs
+++ b/homestar-runtime/src/event_handler/swarm_event.rs
@@ -415,7 +415,8 @@ async fn handle_swarm_event<THandlerErr: fmt::Debug + Send, DB: Database>(
                         info!(
                             peer_id = propagation_source.to_string(),
                             message_id = message_id.to_string(),
-                            "message received on receipts topic: {receipt}"
+                            "message received on receipts topic: {}",
+                            receipt.cid()
                         );
 
                         // Store gossiped receipt.

--- a/homestar-runtime/src/network/webserver.rs
+++ b/homestar-runtime/src/network/webserver.rs
@@ -254,7 +254,7 @@ mod test {
     use super::*;
     #[cfg(feature = "websocket-notify")]
     use crate::event_handler::notification::ReceiptNotification;
-    use crate::{channel::AsyncBoundedChannel, db::Database, settings::Settings};
+    use crate::{channel::AsyncChannel, db::Database, settings::Settings};
     #[cfg(feature = "websocket-notify")]
     use homestar_core::{
         ipld::DagJson,
@@ -290,7 +290,7 @@ mod test {
         runner.runtime.block_on(async {
             let server = Server::new(settings.node().network()).unwrap();
             let metrics_hdl = metrics_handle(settings).await;
-            let (runner_tx, _runner_rx) = AsyncBoundedChannel::oneshot();
+            let (runner_tx, _runner_rx) = AsyncChannel::oneshot();
             server.start(runner_tx, metrics_hdl).await.unwrap();
 
             let ws_url = format!("ws://{}", server.addr);
@@ -332,7 +332,7 @@ mod test {
         runner.runtime.block_on(async {
             let server = Server::new(settings.node().network()).unwrap();
             let metrics_hdl = metrics_handle(settings).await;
-            let (runner_tx, _runner_rx) = AsyncBoundedChannel::oneshot();
+            let (runner_tx, _runner_rx) = AsyncChannel::oneshot();
             server.start(runner_tx, metrics_hdl).await.unwrap();
 
             let ws_url = format!("ws://{}", server.addr);
@@ -365,7 +365,7 @@ mod test {
         runner.runtime.block_on(async {
             let server = Server::new(settings.node().network()).unwrap();
             let metrics_hdl = metrics_handle(settings).await;
-            let (runner_tx, _runner_rx) = AsyncBoundedChannel::oneshot();
+            let (runner_tx, _runner_rx) = AsyncChannel::oneshot();
             server.start(runner_tx, metrics_hdl).await.unwrap();
 
             let ws_url = format!("ws://{}", server.addr);
@@ -442,7 +442,7 @@ mod test {
         runner.runtime.block_on(async {
             let server = Server::new(settings.node().network()).unwrap();
             let metrics_hdl = metrics_handle(settings).await;
-            let (runner_tx, _runner_rx) = AsyncBoundedChannel::oneshot();
+            let (runner_tx, _runner_rx) = AsyncChannel::oneshot();
             server.start(runner_tx, metrics_hdl).await.unwrap();
 
             let ws_url = format!("ws://{}", server.addr);
@@ -476,7 +476,7 @@ mod test {
         runner.runtime.block_on(async {
             let server = Server::new(settings.node().network()).unwrap();
             let metrics_hdl = metrics_handle(settings).await;
-            let (runner_tx, _runner_rx) = AsyncBoundedChannel::oneshot();
+            let (runner_tx, _runner_rx) = AsyncChannel::oneshot();
             server.start(runner_tx, metrics_hdl).await.unwrap();
 
             let ws_url = format!("ws://{}", server.addr);

--- a/homestar-runtime/src/network/webserver/rpc.rs
+++ b/homestar-runtime/src/network/webserver/rpc.rs
@@ -3,7 +3,7 @@ use super::notifier::{self, Header, Notifier, SubscriptionTyp};
 #[allow(unused_imports)]
 use super::{listener, prom::PrometheusData, Message};
 #[cfg(feature = "websocket-notify")]
-use crate::channel::AsyncBoundedChannel;
+use crate::channel::AsyncChannel;
 use crate::runner::WsSender;
 #[cfg(feature = "websocket-notify")]
 use anyhow::anyhow;
@@ -138,7 +138,7 @@ impl JsonRpc {
 
         #[cfg(not(test))]
         module.register_async_method(HEALTH_ENDPOINT, |_, ctx| async move {
-            let (tx, rx) = crate::channel::AsyncBoundedChannel::oneshot();
+            let (tx, rx) = crate::channel::AsyncChannel::oneshot();
             ctx.runner_sender
                 .send_async((Message::GetNodeInfo, Some(tx)))
                 .await
@@ -211,7 +211,7 @@ impl JsonRpc {
             |params, pending, ctx| async move {
                 match params.one::<listener::Run<'_>>() {
                     Ok(listener::Run { name, workflow }) => {
-                        let (tx, rx) = AsyncBoundedChannel::oneshot();
+                        let (tx, rx) = AsyncChannel::oneshot();
                         ctx.runner_sender
                             .send_async((
                                 Message::RunWorkflow((name.clone(), workflow.clone())),

--- a/homestar-runtime/src/settings.rs
+++ b/homestar-runtime/src/settings.rs
@@ -298,7 +298,7 @@ impl Default for Network {
             webserver_host: Uri::from_static("127.0.0.1"),
             webserver_port: 1337,
             webserver_timeout: Duration::new(120, 0),
-            websocket_capacity: 1024,
+            websocket_capacity: 2048,
             websocket_receiver_timeout: Duration::from_millis(30_000),
             workflow_quorum: 3,
             keypair_config: PubkeyConfig::Random,

--- a/homestar-runtime/src/test_utils/event.rs
+++ b/homestar-runtime/src/test_utils/event.rs
@@ -1,26 +1,23 @@
 use crate::{
-    channel::{AsyncBoundedChannel, AsyncBoundedChannelReceiver, AsyncBoundedChannelSender},
+    channel::{AsyncChannel, AsyncChannelReceiver, AsyncChannelSender},
     event_handler::Event,
     settings,
     worker::WorkerMessage,
 };
 
-/// Create an [AsynBoundedChannelSender], [AsyncBoundedChannelReceiver] pair for [Event]s.
+/// Create an [AsynBoundedChannelSender], [AsyncChannelReceiver] pair for [Event]s.
 pub(crate) fn setup_event_channel(
     settings: settings::Node,
-) -> (
-    AsyncBoundedChannelSender<Event>,
-    AsyncBoundedChannelReceiver<Event>,
-) {
-    AsyncBoundedChannel::with(settings.network.events_buffer_len)
+) -> (AsyncChannelSender<Event>, AsyncChannelReceiver<Event>) {
+    AsyncChannel::with(settings.network.events_buffer_len)
 }
 
-/// Create an [AsyncBoundedChannelSender], [AsyncBoundedChannelReceiver] pair for worker messages.
+/// Create an [AsyncChannelSender], [AsyncChannelReceiver] pair for worker messages.
 pub(crate) fn setup_worker_channel(
     settings: settings::Node,
 ) -> (
-    AsyncBoundedChannelSender<WorkerMessage>,
-    AsyncBoundedChannelReceiver<WorkerMessage>,
+    AsyncChannelSender<WorkerMessage>,
+    AsyncChannelReceiver<WorkerMessage>,
 ) {
-    AsyncBoundedChannel::with(settings.network.events_buffer_len)
+    AsyncChannel::with(settings.network.events_buffer_len)
 }

--- a/homestar-runtime/src/test_utils/worker_builder.rs
+++ b/homestar-runtime/src/test_utils/worker_builder.rs
@@ -4,7 +4,7 @@ use super::{db::MemoryDb, event};
 #[cfg(feature = "ipfs")]
 use crate::network::IpfsCli;
 use crate::{
-    channel::AsyncBoundedChannelSender,
+    channel::AsyncChannelSender,
     db::Database,
     event_handler::Event,
     settings,
@@ -29,9 +29,9 @@ use libipld::Cid;
 #[cfg(feature = "ipfs")]
 pub(crate) struct WorkerBuilder<'a> {
     db: MemoryDb,
-    event_sender: AsyncBoundedChannelSender<Event>,
+    event_sender: AsyncChannelSender<Event>,
     ipfs: IpfsCli,
-    runner_sender: AsyncBoundedChannelSender<WorkerMessage>,
+    runner_sender: AsyncChannelSender<WorkerMessage>,
     name: Option<String>,
     workflow: Workflow<'a, Arg>,
     workflow_settings: workflow::Settings,
@@ -41,8 +41,8 @@ pub(crate) struct WorkerBuilder<'a> {
 #[cfg(not(feature = "ipfs"))]
 pub(crate) struct WorkerBuilder<'a> {
     db: MemoryDb,
-    event_sender: AsyncBoundedChannelSender<Event>,
-    runner_sender: AsyncBoundedChannelSender<WorkerMessage>,
+    event_sender: AsyncChannelSender<Event>,
+    runner_sender: AsyncChannelSender<WorkerMessage>,
     name: Option<String>,
     workflow: Workflow<'a, Arg>,
     workflow_settings: workflow::Settings,
@@ -173,13 +173,10 @@ impl<'a> WorkerBuilder<'a> {
         self
     }
 
-    /// Build a [Worker] with a specific Event [AsyncBoundedChannelSender].
+    /// Build a [Worker] with a specific Event [AsyncChannelSender].
     #[allow(dead_code)]
-    pub(crate) fn with_event_sender(
-        mut self,
-        event_sender: AsyncBoundedChannelSender<Event>,
-    ) -> Self {
-        self.event_sender = event_sender.into();
+    pub(crate) fn with_event_sender(mut self, event_sender: AsyncChannelSender<Event>) -> Self {
+        self.event_sender = event_sender;
         self
     }
 

--- a/homestar-runtime/src/workflow/info.rs
+++ b/homestar-runtime/src/workflow/info.rs
@@ -1,6 +1,6 @@
 use super::IndexedResources;
 use crate::{
-    channel::{AsyncBoundedChannel, AsyncBoundedChannelSender},
+    channel::{AsyncChannel, AsyncChannelSender},
     db::{Connection, Database},
     event_handler::{
         event::QueryRecord,
@@ -263,7 +263,7 @@ impl Info {
         name: FastStr,
         resources: IndexedResources,
         p2p_timeout: Duration,
-        event_sender: Arc<AsyncBoundedChannelSender<Event>>,
+        event_sender: Arc<AsyncChannelSender<Event>>,
         mut conn: Connection,
     ) -> Result<(Self, NaiveDateTime)> {
         let timestamp = Utc::now().naive_utc();
@@ -311,7 +311,7 @@ impl Info {
     pub(crate) async fn gather<'a>(
         workflow_cid: Cid,
         p2p_timeout: Duration,
-        event_sender: Arc<AsyncBoundedChannelSender<Event>>,
+        event_sender: Arc<AsyncChannelSender<Event>>,
         mut conn: Option<Connection>,
         handle_timeout_fn: Option<impl FnOnce(Cid, Option<Connection>) -> Result<Self>>,
     ) -> Result<Self> {
@@ -343,11 +343,11 @@ impl Info {
     async fn retrieve_from_query<'a>(
         workflow_cid: Cid,
         p2p_timeout: Duration,
-        event_sender: Arc<AsyncBoundedChannelSender<Event>>,
+        event_sender: Arc<AsyncChannelSender<Event>>,
         conn: Option<Connection>,
         handle_timeout_fn: Option<impl FnOnce(Cid, Option<Connection>) -> Result<Info>>,
     ) -> Result<Info> {
-        let (tx, rx) = AsyncBoundedChannel::oneshot();
+        let (tx, rx) = AsyncChannel::oneshot();
         event_sender
             .send_async(Event::FindRecord(QueryRecord::with(
                 workflow_cid,


### PR DESCRIPTION
Includes:

- a rename of `asyncboundedchannel*` to `asyncchannel` to accomodate unbounded channels
- remove receipt logging with too much output