### PR TITLE
feat: Add CLI workflow run receipts table

### DIFF
--- a/homestar-runtime/src/runner/response.rs
+++ b/homestar-runtime/src/runner/response.rs
@@ -84,7 +84,7 @@ impl show::ConsoleTable for AckWorkflow {
         let mut receipt_table_builder = Builder::default();
         receipt_table_builder.push_record([
             "Replayed Receipt".to_string(),
-            "Ran".to_string(),
+            "Invocation Ran".to_string(),
             "Instruction".to_string(),
         ]);
 

--- a/homestar-runtime/src/runner/response.rs
+++ b/homestar-runtime/src/runner/response.rs
@@ -85,8 +85,9 @@ impl show::ConsoleTable for AckWorkflow {
                 .collect::<Vec<String>>(),
         );
 
-        progress_table
-            .with(Modify::new(Rows::first()).with(Format::content(|_s| "Progress".to_string())));
+        progress_table.with(
+            Modify::new(Rows::first()).with(Format::content(|_s| "Receipts Computed".to_string())),
+        );
 
         let tbl = col![table, resource_table, progress_table].default();
 

--- a/homestar-runtime/src/runner/response.rs
+++ b/homestar-runtime/src/runner/response.rs
@@ -17,7 +17,7 @@ use tabled::{
     Table, Tabled,
 };
 
-type ReceiptInfo = (Cid, Option<(String, String)>);
+use super::WorkflowReceiptInfo;
 
 /// Workflow information specified for response / display upon
 /// acknowledgement of running a workflow.
@@ -30,7 +30,7 @@ pub struct AckWorkflow {
     #[tabled(skip)]
     pub(crate) resources: IndexedResources,
     #[tabled(skip)]
-    pub(crate) receipt_info: Vec<ReceiptInfo>,
+    pub(crate) receipt_info: Vec<WorkflowReceiptInfo>,
     pub(crate) timestamp: String,
 }
 
@@ -48,7 +48,7 @@ impl AckWorkflow {
     /// Workflow information for response / display.
     pub(crate) fn new(
         workflow_info: Arc<workflow::Info>,
-        receipt_info: Vec<ReceiptInfo>,
+        receipt_info: Vec<WorkflowReceiptInfo>,
         name: FastStr,
         timestamp: NaiveDateTime,
     ) -> Self {

--- a/homestar-runtime/src/runner/response.rs
+++ b/homestar-runtime/src/runner/response.rs
@@ -78,7 +78,17 @@ impl show::ConsoleTable for AckWorkflow {
         resource_table
             .with(Modify::new(Rows::first()).with(Format::content(|_s| "Resources".to_string())));
 
-        let tbl = col![table, resource_table].default();
+        let mut progress_table = Table::new(
+            self.progress
+                .iter()
+                .map(|v| v.to_string())
+                .collect::<Vec<String>>(),
+        );
+
+        progress_table
+            .with(Modify::new(Rows::first()).with(Format::content(|_s| "Progress".to_string())));
+
+        let tbl = col![table, resource_table, progress_table].default();
 
         tbl.echo()
     }


### PR DESCRIPTION
# Description

This PR implements the following features:

- [x] Add receipt table to the output of `homestar run`

The receipt table lists replayed receipt CIDs and associated instruction and invocation ran CIDs from a workflow run.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Test plan (required)

Run a workflow. The new table should be empty on first run.  Replayed receipt, instruction, and invocation ran CIDs should be displayed on subsequent runs.

## Screenshots/Screencaps

With replayed receipts:

![CleanShot 2024-01-04 at 09 25 47@2x](https://github.com/ipvm-wg/homestar/assets/7957636/f80b6d7a-92cc-49e3-9a8c-363f69c70d63)

When no replayed receipts were available:

![CleanShot 2024-01-04 at 09 26 09@2x](https://github.com/ipvm-wg/homestar/assets/7957636/bf1fb1c9-6099-48b7-8936-4ca5ed3dce98)


