### PR TITLE
[Draft] Toml generation macro

### DIFF
--- a/homestar-runtime/Cargo.toml
+++ b/homestar-runtime/Cargo.toml
@@ -72,6 +72,7 @@ enum-assoc = { workspace = true }
 faststr = { workspace = true }
 flume = { version = "0.11", default-features = false, features = ["async"] }
 fnv = { version = "1.0", default-features = false }
+function_name = "0.3.0"
 futures = { workspace = true }
 headers = "0.4"
 homestar-core = { version = "0.1", path = "../homestar-core" }
@@ -164,6 +165,7 @@ tokio-stream = { version = "0.1", default-features = false, features = [
   "sync",
 ] }
 tokio-util = { version = "0.7", default-features = false }
+toml = {version = "0.8.8", features = ["preserve_order"]}
 tower = { version = "0.4", default-features = false, features = [
   "log",
   "timeout",

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -1,7 +1,9 @@
+use crate::make_config;
 use crate::utils::{
     check_for_line_with, kill_homestar, retrieve_output, wait_for_socket_connection, ChildGuard,
-    FileGuard, TimeoutFutureExt, BIN_NAME,
+    FileGuard, TimeoutFutureExt, BIN_NAME, TestConfig
 };
+use ::function_name::named;
 use anyhow::Result;
 use homestar_runtime::{db::Database, Db, Settings};
 use itertools::Itertools;
@@ -25,12 +27,48 @@ const SUBSCRIBE_NETWORK_EVENTS_ENDPOINT: &str = "subscribe_network_events";
 const UNSUBSCRIBE_NETWORK_EVENTS_ENDPOINT: &str = "unsubscribe_network_events";
 
 #[test]
+#[named]
 fn test_libp2p_receipt_gossip_integration() -> Result<()> {
     const DB1: &str = "test_libp2p_receipt_gossip_integration1.db";
     const DB2: &str = "_test_libp2p_receipt_gossip_integration2.db";
 
     let _db_guard1 = FileGuard::new(DB1);
     let _db_guard2 = FileGuard::new(DB2);
+
+    let toml_val = toml::toml! {
+        [node]
+
+        [node.monitoring]
+        process_collector_interval = 500
+        console_subscriber_port = 5550
+
+        [node.network.keypair_config]
+        existing = { key_type = "ed25519", path = "./fixtures/__testkey_ed25519.pem" }
+
+        [node.network.libp2p]
+        listen_address = "/ip4/127.0.0.1/tcp/7020"
+        node_addresses = [
+            "/ip4/127.0.0.1/tcp/7021/p2p/16Uiu2HAm3g9AomQNeEctL2hPwLapap7AtPSNt8ZrBny4rLx1W5Dc",
+        ]
+
+        [node.network.libp2p.mdns]
+        enable = false
+
+        [node.network.libp2p.rendezvous]
+        enable_client = false
+
+        [node.network.metrics]
+        port = 3990
+
+        [node.network.rpc]
+        port = 9790
+
+        [node.network.webserver]
+        port = 7990
+    };
+
+    let test_config = make_config!(function_name!(), toml_val);
+    let _ = test_config.create_fixture();
 
     let homestar_proc1 = Command::new(BIN.as_os_str())
         .env(
@@ -39,7 +77,7 @@ fn test_libp2p_receipt_gossip_integration() -> Result<()> {
         )
         .arg("start")
         .arg("-c")
-        .arg("tests/fixtures/test_gossip1.toml")
+        .arg(&test_config.name)
         .arg("--db")
         .arg(DB1)
         .stdout(Stdio::piped())
@@ -68,6 +106,43 @@ fn test_libp2p_receipt_gossip_integration() -> Result<()> {
             .await
             .unwrap();
 
+        let toml_val_2 = toml::toml! {
+            [node]
+
+            [node.monitoring]
+            process_collector_interval = 500
+            console_subscriber_port = 5551
+
+            [node.network.keypair_config]
+            existing = { key_type = "secp256k1", path = "./fixtures/__testkey_secp256k1.der" }
+
+            [node.network.libp2p]
+            listen_address = "/ip4/127.0.0.1/tcp/7021"
+            node_addresses = [
+                "/ip4/127.0.0.1/tcp/7020/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN",
+            ]
+
+            [node.network.libp2p.mdns]
+            enable = false
+
+            [node.network.metrics]
+            port = 3991
+
+            [node.network.libp2p.rendezvous]
+            enable_client = false
+
+            [node.network.rpc]
+            port = 9791
+
+            [node.network.webserver]
+            port = 7991
+        };
+
+        // Should probably figure out how to deal with tests with two configs
+        // currently generates the same name.
+        let test_config_2 = make_config!(concat!(function_name!(), "2"), toml_val_2);
+        let _ = test_config_2.create_fixture();
+
         let homestar_proc2 = Command::new(BIN.as_os_str())
             .env(
                 "RUST_LOG",
@@ -75,7 +150,7 @@ fn test_libp2p_receipt_gossip_integration() -> Result<()> {
             )
             .arg("start")
             .arg("-c")
-            .arg("tests/fixtures/test_gossip2.toml")
+            .arg(&test_config_2.name)
             .arg("--db")
             .arg(DB2)
             .stdout(Stdio::piped())

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -1,7 +1,7 @@
 use crate::make_config;
 use crate::utils::{
     check_for_line_with, kill_homestar, retrieve_output, wait_for_socket_connection, ChildGuard,
-    FileGuard, TimeoutFutureExt, BIN_NAME, TestConfig
+    FileGuard, TestConfig, TimeoutFutureExt, BIN_NAME,
 };
 use ::function_name::named;
 use anyhow::Result;
@@ -35,7 +35,7 @@ fn test_libp2p_receipt_gossip_integration() -> Result<()> {
     let _db_guard1 = FileGuard::new(DB1);
     let _db_guard2 = FileGuard::new(DB2);
 
-    let toml_val = toml::toml! {
+    let toml = r#"
         [node]
 
         [node.monitoring]
@@ -65,10 +65,9 @@ fn test_libp2p_receipt_gossip_integration() -> Result<()> {
 
         [node.network.webserver]
         port = 7990
-    };
+    "#;
 
-    let test_config = make_config!(function_name!(), toml_val);
-    let _ = test_config.create_fixture();
+    let test_config = make_config!(toml);
 
     let homestar_proc1 = Command::new(BIN.as_os_str())
         .env(
@@ -106,7 +105,7 @@ fn test_libp2p_receipt_gossip_integration() -> Result<()> {
             .await
             .unwrap();
 
-        let toml_val_2 = toml::toml! {
+        let toml_val_2 = r#"
             [node]
 
             [node.monitoring]
@@ -136,11 +135,9 @@ fn test_libp2p_receipt_gossip_integration() -> Result<()> {
 
             [node.network.webserver]
             port = 7991
-        };
+        "#;
 
-        // Should probably figure out how to deal with tests with two configs
-        // currently generates the same name.
-        let test_config_2 = make_config!(concat!(function_name!(), "2"), toml_val_2);
+        let test_config_2 = make_config!("gossip_2", toml_val_2);
         let _ = test_config_2.create_fixture();
 
         let homestar_proc2 = Command::new(BIN.as_os_str())

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -1,7 +1,9 @@
-use crate::make_config;
-use crate::utils::{
-    check_for_line_with, kill_homestar, retrieve_output, wait_for_socket_connection, ChildGuard,
-    FileGuard, TestConfig, TimeoutFutureExt, BIN_NAME,
+use crate::{
+    make_config,
+    utils::{
+        check_for_line_with, kill_homestar, retrieve_output, wait_for_socket_connection,
+        ChildGuard, FileGuard, TestConfig, TimeoutFutureExt, BIN_NAME,
+    },
 };
 use ::function_name::named;
 use anyhow::Result;

--- a/homestar-runtime/tests/utils.rs
+++ b/homestar-runtime/tests/utils.rs
@@ -348,26 +348,24 @@ impl Drop for TestConfig {
 }
 #[macro_export]
 macro_rules! make_config {
-    // No args just generates the default config for homestar
-    () => {{
-        let name = concat!("tests/fixtures/", function_name!(), ".toml");
-        TestConfig {
-            name: name.to_string(),
-            toml_config: "".to_string(),
-        }
-    }};
+    // For tests where all you want to do is write toml.
     ($toml:expr) => {{
         let name = concat!("tests/fixtures/", function_name!(), ".toml");
-        TestConfig {
-            name: name.to_string();
-            toml_config: $toml
-        }
+        let toml = $toml.parse::<toml::Table>().unwrap();
+        let test_config = TestConfig {
+            name: name.to_string(),
+            toml_config: toml,
+        };
+        test_config.create_fixture();
+        test_config
     }};
+    // For some finer control over the config
     ($name:expr, $toml:expr) => {{
-        let name = concat!("tests/fixtures/", $name, ".toml");
+        let name = concat!("tests/fixtures/", function_name!(), $name, ".toml");
+        let toml = $toml.parse::<toml::Table>().unwrap();
         TestConfig {
             name: name.to_string(),
-            toml_config: $toml,
+            toml_config: toml,
         }
     }};
 }

--- a/homestar-runtime/tests/utils.rs
+++ b/homestar-runtime/tests/utils.rs
@@ -13,11 +13,11 @@ use predicates::prelude::*;
 use retry::delay::Fixed;
 use retry::{delay::Exponential, retry};
 use serde::Serialize;
-use std::io::Write;
 use std::{
     env, fs,
     fs::File,
     future::Future,
+    io::Write,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, TcpStream},
     path::PathBuf,
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},


### PR DESCRIPTION
# Description
Allows us to write inline toml configs for tests. As we can see the amount of .toml configs is starting to get quite large. The macro allows us to write toml configs inside tests, create a fixture file and then discard it when the test is finished. As an example I have changed the gossip test to accommodate the macro.

## Link to issue

[Issue#485](https://github.com/ipvm-wg/homestar/issues/485)

## Type of change

- [X] Refactor (non-breaking change that updates existing functionality)
- [X] This change requires a documentation update

Please delete options that are not relevant.

## Test plan (required)

Gossip test is passing, will proceed to change more tests after discussion about initial macro implementation.
