### PR TITLE
fix: add handling of dns multiaddrs + bootstrapping + CLI / Conn changes

### DIFF
--- a/.github/workflows/tests_and_checks.yml
+++ b/.github/workflows/tests_and_checks.yml
@@ -46,7 +46,7 @@ jobs:
 
   run-checks:
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.examples == 'true' }}
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
@@ -210,7 +210,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
     env:
-      RUSTFLAGS: -Dwarnings  -Ctarget-feature=+crt-static
+      RUSTFLAGS: -Dwarnings -Ctarget-feature=+crt-static
     strategy:
       fail-fast: false
       matrix:
@@ -262,6 +262,9 @@ jobs:
   run-cargo-tests:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     runs-on: ubuntu-latest
     steps:
       - name: Setup IPFS
@@ -283,11 +286,14 @@ jobs:
           shared-key: test-all-stable-ubuntu-latest
           save-if: ${{ github.event_name == 'push' }}
 
+      - name: Sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+
       - name: Run Tests (all-features)
         run: cargo test --workspace --all-features
 
   run-docs:
-    needs: changes
+    needs: [changes]
     if: ${{ needs.changes.outputs.rust == 'true' }}
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -306,6 +312,7 @@ jobs:
       - name: Cache Project
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: true
           shared-key: doc
           save-if: ${{ github.event_name == 'push' }}
 
@@ -316,3 +323,42 @@ jobs:
         env:
           RUSTDOCFLAGS: -Dwarnings
         run: cargo doc --workspace --document-private-items
+
+  build-and-run-examples:
+    needs: changes
+    if: ${{ needs.changes.outputs.examples == 'true' }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup IPFS
+        uses: ibnesayeed/setup-ipfs@master
+        with:
+          run_daemon: false
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Use mold-linker
+        uses: rui314/setup-mold@v1
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache Project
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: cargo-examples
+          save-if: ${{ github.event_name == 'push' }}
+
+      - name: Sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+
+      - name: Build example-websocket-relay
+        run: cargo build -p websocket-relay
+
+      - name: Run example-websocket-relay
+        shell: bash
+        run: timeout 10s cargo run -p websocket-relay || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2630,7 @@ dependencies = [
  "typetag",
  "url",
  "uuid",
+ "vergen",
  "wait-timeout",
  "winapi",
 ]
@@ -2722,6 +2737,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsqlite3-sys",
  "linux-raw-sys",
+ "memchr",
  "miette",
  "miniz_oxide",
  "multibase",
@@ -2738,6 +2754,7 @@ dependencies = [
  "rustix",
  "rustls 0.21.10",
  "scopeguard",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -4683,6 +4700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6208,7 +6234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
 dependencies = [
  "bytecount",
- "cargo_metadata",
+ "cargo_metadata 0.14.2",
  "error-chain",
  "glob",
  "pulldown-cmark",
@@ -6711,6 +6737,8 @@ checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -7403,6 +7431,20 @@ name = "vec1"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bda7c41ca331fe9a1c278a9e7ee055f4be7f5eb1c2b72f079b4ff8b5fce9d5c"
+
+[[package]]
+name = "vergen"
+version = "8.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.18.1",
+ "cfg-if",
+ "regex",
+ "rustversion",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,6 +2548,7 @@ dependencies = [
  "flume 0.11.0",
  "fnv",
  "futures",
+ "hickory-resolver",
  "homestar-invocation",
  "homestar-runtime-tests-proc-macro",
  "homestar-wasm",
@@ -2735,6 +2736,7 @@ dependencies = [
  "ring 0.17.7",
  "rustc-hash",
  "rustix",
+ "rustls 0.21.10",
  "scopeguard",
  "serde",
  "serde_json",
@@ -3289,7 +3291,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.0",
 ]
 
 [[package]]
@@ -3545,6 +3547,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
+ "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr 0.18.1",
  "pin-project",
@@ -3690,6 +3693,7 @@ dependencies = [
  "multihash 0.19.1",
  "quick-protobuf",
  "rand",
+ "ring 0.17.7",
  "serde",
  "sha2 0.10.8",
  "thiserror",
@@ -3947,6 +3951,26 @@ dependencies = [
  "tokio",
  "tracing",
  "void",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4846d51afd08180e164291c3754ba30dd4fbac6fac65571be56403c16431a5e"
+dependencies = [
+ "either",
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot",
+ "pin-project-lite",
+ "rw-stream-sink",
+ "soketto",
+ "tracing",
+ "url",
+ "webpki-roots 0.25.3",
 ]
 
 [[package]]
@@ -8048,6 +8072,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "webpki-roots"

--- a/examples/websocket-relay/README.md
+++ b/examples/websocket-relay/README.md
@@ -64,8 +64,8 @@ if they've been previously run.
 - On macOS, for example, a simple homebrew install would install everything you
   need: `brew install rust npm ipfs`.
 
-- Running `homestar` via `cargo run` here requires a minimum Rust version of
-  `1.73.0`. If you've got an older install of rust, update it with
+- Running `homestar` using `cargo run` requires a minimum Rust version of
+  `1.73.0`. If you've got an older version of rust, update it with
   `rustup update`.
 
 - You do not have to start Kubo (IPFS) on your own. The example will do this

--- a/examples/websocket-relay/README.md
+++ b/examples/websocket-relay/README.md
@@ -88,7 +88,7 @@ if they've been previously run.
 - We have officially packaged homestar binaries using brew, so
   `brew install fission-codes/fission/homestar` will install mostly everything
   you need, including `ipfs`. You will still need `npm` to run this example, and
-  you'll have to manually `ipfs add` the `synthcat.ping` and `example_test.wasm`
+  you'll have to manually `ipfs add` the `synthcat.png` and `example_test.wasm`
   files located in this directory. Then, from this folder, you can then run the
   example like this:
 

--- a/examples/websocket-relay/README.md
+++ b/examples/websocket-relay/README.md
@@ -96,9 +96,9 @@ if they've been previously run.
   homestar start --db homestar.db
   ```
 
-  Afterward, as mentioned above, you can then run `npm install --prefix relay-app` to
-  install dependencies and `npm run --prefix relay-app dev` to start the
-  relay web application (UI) on `http://localhost:5173/` by default.
+  Afterward, run `npm install --prefix relay-app` to install dependencies
+  and `npm run --prefix relay-app dev` to start the relay web
+  application (UI) on `http://localhost:5173/` by default.
 
 
 [@fission-codes/homestar]: https://www.npmjs.com/package/@fission-codes/homestar

--- a/examples/websocket-relay/README.md
+++ b/examples/websocket-relay/README.md
@@ -35,7 +35,7 @@ To get started, please install:
 
 ## Usage
 
-1. Run `cargo run -- start` to start the runtime and an IPFS daemon as a
+1. Run `cargo run` to start the runtime and an IPFS daemon as a
    background process. This runtime includes ANSI-coded logging by default.
 
 2. In a separate terminal window, run `npm install --prefix relay-app` to
@@ -61,38 +61,45 @@ if they've been previously run.
 
 ## Tips & Common Issues
 
-On macOS, for example, a simple homebrew install would install everything you
-need: `brew install rust npm ipfs`
+- On macOS, for example, a simple homebrew install would install everything you
+  need: `brew install rust npm ipfs`.
 
-We have packaged homestar binaries using brew, so
-`brew install fission-codes/fission/homestar` will install everything you need,
-including `ipfs`. You will still need `npm` to run this example. From this folder,
-you can then run the example like this:
+- Running `homestar` via `cargo run` here requires a minimum Rust version of
+  `1.73.0`. If you've got an older install of rust, update it with
+  `rustup update`.
 
-```
-homestar start --db homestar.db
-```
+- You do not have to start Kubo (IPFS) on your own. The example will do this
+  for you, and use `examples/websocket-relay/tmp/.ipfs` as a local blockstore.
+  Feel free to discard it when you don't need it.
 
-Running `homestar` via `cargo run` requires a minimum Rust version of
-`1.73.0`. If you've got an older install of rust, update it with
-`rustup update`.
+- If you're already running an IPFS instance, for example [IPFS Desktop][ipfs-desktop],
+  the application will check for it and not start a new, local one.
+  However, the application expects a default IPFS host and port. The expected
+  IPFS `host` and `port` can be updated in the `homestar` network settings:
 
-You do not have to start Kubo (IPFS) on your own. The example will do this
-for you, and use `examples/websocket-relay/tmp/.ipfs` as a local blockstore.
-Feel free to discard it when you don't need it.
+  ``` toml
+  [node]
 
-If you're already running an IPFS instance, for example [IPFS Desktop][ipfs-desktop],
-the application will check for it and not start a new, local one.
-However, the application expects a default IPFS host and port. The expected
-IPFS `host` and `port` can be updated in the `homestar` network settings:
+  [node.network.ipfs]
+  host = "127.0.0.1"
+  port = 5001
+  ```
 
-``` toml
-[node]
+- We have officially packaged homestar binaries using brew, so
+  `brew install fission-codes/fission/homestar` will install mostly everything
+  you need, including `ipfs`. You will still need `npm` to run this example, and
+  you'll have to manually `ipfs add` the `synthcat.ping` and `example_test.wasm`
+  files located in this directory. Then, from this folder, you can then run the
+  example like this:
 
-[node.network.ipfs]
-host = "127.0.0.1"
-port = 5001
-```
+  ```
+  homestar start --db homestar.db
+  ```
+
+  Afterward, as mentioned above, you can then run `npm install --prefix relay-app` to
+  install dependencies and `npm run --prefix relay-app dev` to start the
+  relay web application (UI) on `http://localhost:5173/` by default.
+
 
 [@fission-codes/homestar]: https://www.npmjs.com/package/@fission-codes/homestar
 [install-ipfs]: https://docs.ipfs.tech/install/

--- a/examples/websocket-relay/README.md
+++ b/examples/websocket-relay/README.md
@@ -89,7 +89,7 @@ if they've been previously run.
   `brew install fission-codes/fission/homestar` will install mostly everything
   you need, including `ipfs`. You will still need `npm` to run this example, and
   you'll have to manually `ipfs add` the `synthcat.png` and `example_test.wasm`
-  files located in this directory. Then, from this folder, you can then run the
+  files located in this directory. Then, from this folder, you can run the
   example like this:
 
   ```

--- a/homestar-runtime/Cargo.toml
+++ b/homestar-runtime/Cargo.toml
@@ -67,6 +67,7 @@ faststr = { workspace = true }
 flume = { version = "0.11", default-features = false, features = ["async"] }
 fnv = { version = "1.0", default-features = false }
 futures = { workspace = true }
+hickory-resolver = { version = "0.24", default-features = false }
 homestar-invocation = { version = "0.1", path = "../homestar-invocation", features = [
   "diesel",
 ] }
@@ -88,6 +89,7 @@ jsonrpsee = { version = "0.21", default-features = false, features = [
 ] }
 libipld = { workspace = true }
 libp2p = { version = "0.53", default-features = false, features = [
+  "dns",
   "kad",
   "request-response",
   "rendezvous",
@@ -97,12 +99,15 @@ libp2p = { version = "0.53", default-features = false, features = [
   "mdns",
   "gossipsub",
   "request-response",
+  "rsa",
   "tokio",
   "tcp",
   "noise",
   "cbor",
   "yamux",
   "serde",
+  "quic",
+  "websocket",
 ] }
 libsqlite3-sys = { workspace = true }
 maplit = "1.0"

--- a/homestar-runtime/Cargo.toml
+++ b/homestar-runtime/Cargo.toml
@@ -190,6 +190,14 @@ uuid = { version = "1.6.1", features = ["v4"] }
 [target.'cfg(not(windows))'.dependencies]
 daemonize = "0.5"
 
+[build-dependencies]
+vergen = { version = "8.3", default-features = false, features = [
+  "build",
+  "cargo",
+  "git",
+  "gitcl",
+] }
+
 [dev-dependencies]
 assert_cmd = "2.0"
 criterion = "0.5"

--- a/homestar-runtime/build.rs
+++ b/homestar-runtime/build.rs
@@ -1,3 +1,14 @@
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=migrations");
+
+    vergen::EmitBuilder::builder()
+        .fail_on_error()
+        .use_local_build()
+        .git_sha(true)
+        .cargo_features()
+        .emit()?;
+
+    println!("cargo:rerun-if-changed=build.rs");
+
+    Ok(())
 }

--- a/homestar-runtime/config/defaults.toml
+++ b/homestar-runtime/config/defaults.toml
@@ -27,6 +27,10 @@ transport_connection_timeout = 60
 max_connected_peers = 32
 max_announce_addresses = 10
 dial_interval = 30
+bootstrap_interval = 30
+
+[node.network.libp2p.quic]
+enable = true
 
 [node.network.libp2p.mdns]
 enable = true

--- a/homestar-runtime/src/cli.rs
+++ b/homestar-runtime/src/cli.rs
@@ -17,7 +17,7 @@ use tarpc::context;
 mod error;
 pub use error::Error;
 pub(crate) mod show;
-pub(crate) use show::ConsoleTable;
+pub use show::ConsoleTable;
 
 const DEFAULT_DB_PATH: &str = "homestar.db";
 const TMP_DIR: &str = "/tmp";
@@ -151,6 +151,8 @@ Supported:
         #[clap(flatten)]
         args: RpcArgs,
     },
+    /// Get Homestar binary and other information.
+    Info,
 }
 
 impl Command {
@@ -161,6 +163,7 @@ impl Command {
             Command::Ping { .. } => "ping",
             Command::Run { .. } => "run",
             Command::Node { .. } => "node",
+            Command::Info => "info",
         }
     }
 

--- a/homestar-runtime/src/cli/show.rs
+++ b/homestar-runtime/src/cli/show.rs
@@ -55,6 +55,7 @@ pub(crate) trait ConsoleTable {
 /// Style trait for console table output responses.
 pub(crate) trait ApplyStyle {
     fn default(&mut self) -> Output;
+    fn default_with_title(&mut self, ext_title: &str) -> Output;
 }
 
 impl ApplyStyle for Table {
@@ -62,6 +63,18 @@ impl ApplyStyle for Table {
         let table = self
             .with(Style::modern())
             .with(Panel::header(TABLE_TITLE))
+            .with(Modify::new(Rows::first()).with(Alignment::left()))
+            .with(BorderColor::filled(Color::FG_WHITE))
+            .with(BorderSpanCorrection)
+            .to_string();
+
+        Output(table)
+    }
+
+    fn default_with_title(&mut self, ext_title: &str) -> Output {
+        let table = self
+            .with(Style::modern())
+            .with(Panel::header(format!("{TABLE_TITLE} - {ext_title}")))
             .with(Modify::new(Rows::first()).with(Alignment::left()))
             .with(BorderColor::filled(Color::FG_WHITE))
             .with(BorderSpanCorrection)

--- a/homestar-runtime/src/cli/show.rs
+++ b/homestar-runtime/src/cli/show.rs
@@ -18,7 +18,7 @@ pub(crate) const TABLE_TITLE: &str = "homestar(╯°□°)╯";
 
 /// Output response wrapper.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Output(String);
+pub struct Output(String);
 
 impl fmt::Display for Output {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -47,8 +47,10 @@ impl Output {
 }
 
 /// Trait for console table output responses.
-pub(crate) trait ConsoleTable {
+pub trait ConsoleTable {
+    /// Get the table as an output response.
     fn table(&self) -> Output;
+    /// Print the table to console.
     fn echo_table(&self) -> Result<(), io::Error>;
 }
 

--- a/homestar-runtime/src/event_handler/cache.rs
+++ b/homestar-runtime/src/event_handler/cache.rs
@@ -3,8 +3,11 @@
 use crate::{channel, event_handler::Event};
 use libp2p::PeerId;
 use moka::{
-    future::Cache,
-    notification::RemovalCause::{self, Expired},
+    future::{Cache, FutureExt},
+    notification::{
+        ListenerFuture,
+        RemovalCause::{self, Expired},
+    },
     Expiry as ExpiryBase,
 };
 use std::{
@@ -49,6 +52,7 @@ pub(crate) enum CacheData {
 /// Events to be dispatched on cache expiration.
 #[derive(Clone, Debug)]
 pub(crate) enum DispatchEvent {
+    Bootstrap,
     RegisterPeer,
     DiscoverPeers,
     DialPeer,
@@ -58,38 +62,51 @@ pub(crate) enum DispatchEvent {
 pub(crate) fn setup_cache(
     sender: Arc<channel::AsyncChannelSender<Event>>,
 ) -> Cache<String, CacheValue> {
-    let eviction_listener = move |_key: Arc<String>, val: CacheValue, cause: RemovalCause| {
+    let eviction_listener = move |_key: Arc<String>,
+                                  val: CacheValue,
+                                  cause: RemovalCause|
+          -> ListenerFuture {
         let tx = Arc::clone(&sender);
 
-        if let Some(CacheData::OnExpiration(event)) = val.data.get("on_expiration") {
-            if cause != Expired {
-                return;
-            }
-
-            match event {
-                DispatchEvent::RegisterPeer => {
-                    if let Some(CacheData::Peer(rendezvous_node)) = val.data.get("rendezvous_node")
-                    {
-                        let _ = tx.send(Event::RegisterPeer(rendezvous_node.to_owned()));
-                    };
-                }
-                DispatchEvent::DiscoverPeers => {
-                    if let Some(CacheData::Peer(rendezvous_node)) = val.data.get("rendezvous_node")
-                    {
-                        let _ = tx.send(Event::DiscoverPeers(rendezvous_node.to_owned()));
-                    };
-                }
-                DispatchEvent::DialPeer => {
-                    if let Some(CacheData::Peer(node)) = val.data.get("node") {
-                        let _ = tx.send(Event::DialPeer(node.to_owned()));
-                    };
+        async move {
+            if let Some(CacheData::OnExpiration(event)) = val.data.get("on_expiration") {
+                if cause == Expired {
+                    match event {
+                        DispatchEvent::Bootstrap => {
+                            let _ = tx.send_async(Event::Bootstrap).await;
+                        }
+                        DispatchEvent::RegisterPeer => {
+                            if let Some(CacheData::Peer(rendezvous_node)) =
+                                val.data.get("rendezvous_node")
+                            {
+                                let _ = tx
+                                    .send_async(Event::RegisterPeer(rendezvous_node.to_owned()))
+                                    .await;
+                            };
+                        }
+                        DispatchEvent::DiscoverPeers => {
+                            if let Some(CacheData::Peer(rendezvous_node)) =
+                                val.data.get("rendezvous_node")
+                            {
+                                let _ = tx
+                                    .send_async(Event::DiscoverPeers(rendezvous_node.to_owned()))
+                                    .await;
+                            };
+                        }
+                        DispatchEvent::DialPeer => {
+                            if let Some(CacheData::Peer(node)) = val.data.get("node") {
+                                let _ = tx.send(Event::DialPeer(node.to_owned()));
+                            };
+                        }
+                    }
                 }
             }
         }
+        .boxed()
     };
 
     Cache::builder()
         .expire_after(Expiry)
-        .eviction_listener(eviction_listener)
+        .async_eviction_listener(eviction_listener)
         .build()
 }

--- a/homestar-runtime/src/event_handler/event.rs
+++ b/homestar-runtime/src/event_handler/event.rs
@@ -134,6 +134,8 @@ pub(crate) enum Event {
     GetNodeInfo(AsyncChannelSender<DynamicNodeInfo>),
     /// Dial a peer.
     DialPeer(PeerId),
+    /// Bootstrap the node to join the DHT.
+    Bootstrap,
 }
 
 #[allow(unreachable_patterns)]
@@ -301,6 +303,34 @@ impl Event {
                     .dial(peer_id)
                     .map_err(anyhow::Error::new)?;
             }
+            Event::Bootstrap => {
+                if event_handler
+                    .swarm
+                    .connected_peers()
+                    .peekable()
+                    .peek()
+                    .is_some()
+                {
+                    let _ = event_handler
+                        .swarm
+                        .behaviour_mut()
+                        .kademlia
+                        .bootstrap()
+                        .map(|_| {
+                            debug!(
+                                subject = "libp2p.kad.bootstrap",
+                                category = "handle_event",
+                                "bootstrapped kademlia"
+                            )
+                        })
+                        .map_err(|err| {
+                            warn!(subject = "libp2p.kad.bootstrap.err",
+                          category = "handle_event",
+                          err=?err,
+                          "error bootstrapping kademlia")
+                        });
+                }
+            }
             _ => {}
         }
         Ok(())
@@ -391,14 +421,14 @@ impl Captured {
             }
         }
 
-        let receipt_quorum = if event_handler.receipt_quorum > 0 {
-            unsafe { Quorum::N(NonZeroUsize::new_unchecked(event_handler.receipt_quorum)) }
+        let receipt_quorum = if event_handler.quorum.receipt > 0 {
+            unsafe { Quorum::N(NonZeroUsize::new_unchecked(event_handler.quorum.receipt)) }
         } else {
             Quorum::One
         };
 
-        let workflow_quorum = if event_handler.workflow_quorum > 0 {
-            unsafe { Quorum::N(NonZeroUsize::new_unchecked(event_handler.receipt_quorum)) }
+        let workflow_quorum = if event_handler.quorum.workflow > 0 {
+            unsafe { Quorum::N(NonZeroUsize::new_unchecked(event_handler.quorum.receipt)) }
         } else {
             Quorum::One
         };

--- a/homestar-runtime/src/event_handler/event.rs
+++ b/homestar-runtime/src/event_handler/event.rs
@@ -304,6 +304,10 @@ impl Event {
                     .map_err(anyhow::Error::new)?;
             }
             Event::Bootstrap => {
+                // Bootstrapping requires at least one node of the DHT to be
+                // known.
+                //
+                // See `libp2p::Behaviour::add_address`.
                 if event_handler
                     .swarm
                     .connected_peers()

--- a/homestar-runtime/src/event_handler/swarm_event.rs
+++ b/homestar-runtime/src/event_handler/swarm_event.rs
@@ -1090,7 +1090,12 @@ async fn handle_swarm_event<DB: Database>(
                 },
             );
 
-            // Bootstrap the DHT
+            // Init bootstrapping of the DHT
+            //
+            // Bootstrapping requires at least one node of the DHT to be
+            // known.
+            //
+            // See `libp2p::Behaviour::add_address`.
             if event_handler
                 .swarm
                 .connected_peers()

--- a/homestar-runtime/src/main.rs
+++ b/homestar-runtime/src/main.rs
@@ -1,11 +1,12 @@
 use clap::Parser;
 use homestar_runtime::{
-    cli::{Cli, Command},
+    cli::{Cli, Command, ConsoleTable},
     daemon,
     db::Database,
+    runner::response,
     Db, FileLogger, Logger, Runner, Settings,
 };
-use miette::Result;
+use miette::{miette, Result};
 use tracing::info;
 
 fn main() -> Result<()> {
@@ -54,6 +55,12 @@ fn main() -> Result<()> {
 
             info!("starting Homestar runtime...");
             Runner::start(settings, db).expect("Failed to start runtime")
+        }
+        Command::Info => {
+            let response = response::Info::default();
+            response
+                .echo_table()
+                .map_err(|_| miette!("failed to extract binary information"))?
         }
         cmd => cmd.handle_rpc_command()?,
     }

--- a/homestar-runtime/src/network/webserver/rpc.rs
+++ b/homestar-runtime/src/network/webserver/rpc.rs
@@ -182,7 +182,6 @@ where
             }
         })?;
 
-        #[cfg(not(test))]
         module.register_async_method(NODE_INFO_ENDPOINT, |_, ctx| async move {
             let (tx, rx) = crate::channel::AsyncChannel::oneshot();
             ctx.runner_sender

--- a/homestar-runtime/src/runner.rs
+++ b/homestar-runtime/src/runner.rs
@@ -45,7 +45,7 @@ use tracing::{debug, error, info, warn};
 mod error;
 pub(crate) mod file;
 mod nodeinfo;
-pub(crate) mod response;
+pub mod response;
 pub(crate) use error::Error;
 pub(crate) use nodeinfo::{DynamicNodeInfo, StaticNodeInfo};
 

--- a/homestar-runtime/src/runner/nodeinfo.rs
+++ b/homestar-runtime/src/runner/nodeinfo.rs
@@ -2,13 +2,20 @@
 
 use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
+use tabled::Tabled;
 
 /// Static node information available at startup.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Tabled)]
 pub(crate) struct StaticNodeInfo {
     /// The [PeerId] of a node.
     pub(crate) peer_id: PeerId,
+}
+
+impl fmt::Display for StaticNodeInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "peer_id: {}", self.peer_id)
+    }
 }
 
 impl StaticNodeInfo {
@@ -32,6 +39,16 @@ pub(crate) struct DynamicNodeInfo {
     pub(crate) listeners: Vec<Multiaddr>,
     /// Connections for the node.
     pub(crate) connections: HashMap<PeerId, Multiaddr>,
+}
+
+impl fmt::Display for DynamicNodeInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "listeners: {:?}, connections: {:?}",
+            self.listeners, self.connections
+        )
+    }
 }
 
 impl DynamicNodeInfo {

--- a/homestar-runtime/src/runner/response.rs
+++ b/homestar-runtime/src/runner/response.rs
@@ -118,7 +118,7 @@ impl show::ConsoleTable for AckWorkflow {
 }
 
 /// Ping response for display.
-#[derive(Tabled)]
+#[derive(Debug, Tabled)]
 pub(crate) struct Ping {
     address: SocketAddr,
     response: String,
@@ -214,5 +214,40 @@ impl show::ConsoleTable for AckNodeInfo {
         let tbl = col![static_info_table, listeners_table, conns_table].default_with_title("node");
 
         tbl.echo()
+    }
+}
+
+/// Info response for display.
+#[derive(Debug, Tabled)]
+pub struct Info {
+    version: String,
+    git_sha: String,
+    features: String,
+}
+
+impl Default for Info {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Info {
+    /// Create a new [Info] response.
+    pub(crate) fn new() -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            git_sha: env!("VERGEN_GIT_SHA").to_string(),
+            features: env!("VERGEN_CARGO_FEATURES").to_string(),
+        }
+    }
+}
+
+impl show::ConsoleTable for Info {
+    fn table(&self) -> show::Output {
+        Table::new(vec![&self]).default_with_title("info")
+    }
+
+    fn echo_table(&self) -> Result<(), std::io::Error> {
+        self.table().echo()
     }
 }

--- a/homestar-runtime/src/settings/libp2p_config.rs
+++ b/homestar-runtime/src/settings/libp2p_config.rs
@@ -30,6 +30,8 @@ pub(crate) struct Libp2p {
     /// Multiaddrs of the trusted nodes to connect to on startup.
     #[serde_as(as = "Vec<serde_with::DisplayFromStr>")]
     pub(crate) node_addresses: Vec<libp2p::Multiaddr>,
+    /// Quic Settings.
+    pub(crate) quic: Quic,
     /// mDNS Settings.
     pub(crate) mdns: Mdns,
     /// Pubsub Settings.
@@ -42,6 +44,16 @@ pub(crate) struct Libp2p {
     /// Dial interval.
     #[serde_as(as = "DurationSeconds<u64>")]
     pub(crate) dial_interval: Duration,
+    /// Bootstrap dial interval.
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub(crate) bootstrap_interval: Duration,
+}
+
+/// DHT settings.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub(crate) struct Quic {
+    /// Enable Quic transport.
+    pub(crate) enable: bool,
 }
 
 /// DHT settings.
@@ -136,12 +148,14 @@ impl Default for Libp2p {
             listen_address: Uri::from_static("/ip4/0.0.0.0/tcp/0"),
             max_connected_peers: 32,
             max_announce_addresses: 10,
+            quic: Quic::default(),
             mdns: Mdns::default(),
             node_addresses: Vec::new(),
             pubsub: Pubsub::default(),
             rendezvous: Rendezvous::default(),
             transport_connection_timeout: Duration::new(60, 0),
             dial_interval: Duration::new(30, 0),
+            bootstrap_interval: Duration::new(30, 0),
         }
     }
 }
@@ -167,6 +181,12 @@ impl Default for Dht {
             receipt_quorum: 2,
             workflow_quorum: 3,
         }
+    }
+}
+
+impl Default for Quic {
+    fn default() -> Self {
+        Self { enable: true }
     }
 }
 

--- a/homestar-runtime/tests/network.rs
+++ b/homestar-runtime/tests/network.rs
@@ -280,6 +280,7 @@ fn test_libp2p_connect_known_peers_integration() -> Result<()> {
         [node.network.libp2p]
         listen_address = "{listen_addr1}"
         node_addresses = ["{node_addrb}"]
+        bootstrap_interval = 1
         [node.network.libp2p.mdns]
         enable = false
         [node.network.libp2p.rendezvous]
@@ -388,6 +389,12 @@ fn test_libp2p_connect_known_peers_integration() -> Result<()> {
     let stdout1 = retrieve_output(dead_proc1);
     let stdout2 = retrieve_output(dead_proc2);
 
+    // Check that node bootsrapped itself on the 1 second delay.
+    let bootstrapped = check_for_line_with(
+        stdout1.clone(),
+        vec!["successfully bootstrapped node", ED25519MULTIHASH],
+    );
+
     // Check node two was added to the Kademlia table
     let two_added_to_dht = check_for_line_with(
         stdout1.clone(),
@@ -412,6 +419,7 @@ fn test_libp2p_connect_known_peers_integration() -> Result<()> {
         vec!["peer connection established", SECP256K1MULTIHASH],
     );
 
+    assert!(bootstrapped);
     assert!(one_connected_to_two);
     assert!(two_in_dht_routing_table);
     assert!(two_added_to_dht);
@@ -568,6 +576,76 @@ fn test_libp2p_disconnect_known_peers_integration() -> Result<()> {
 
     assert!(two_disconnected_from_one);
     assert!(!two_removed_from_dht_table);
+
+    Ok(())
+}
+
+#[test]
+#[serial_test::parallel]
+fn test_libp2p_configured_with_known_dns_multiaddr() -> Result<()> {
+    let proc_info = ProcInfo::new().unwrap();
+    let rpc_port = proc_info.rpc_port;
+    let metrics_port = proc_info.metrics_port;
+    let ws_port = proc_info.ws_port;
+    let listen_addr = listen_addr(proc_info.listen_port);
+
+    let known_peer_id = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN";
+    // from ipfs bootstrap list
+    let dns_node_addr = format!("/dnsaddr/bootstrap.libp2p.io/p2p/{}", known_peer_id);
+    let toml = format!(
+        r#"
+        [node]
+        [node.network.keypair_config]
+        existing = {{ key_type = "ed25519", path = "./fixtures/__testkey_ed25519_2.pem" }}
+        [node.network.libp2p]
+        listen_address = "{listen_addr}"
+        node_addresses = ["{dns_node_addr}"]
+        [node.network.libp2p.mdns]
+        enable = false
+        [node.network.libp2p.rendezvous]
+        enable_client = false
+        enable_server = false
+        [node.network.metrics]
+        port = {metrics_port}
+        [node.network.rpc]
+        port = {rpc_port}
+        [node.network.webserver]
+        port = {ws_port}
+        "#
+    );
+
+    let config = make_config!(toml);
+
+    let homestar_proc = Command::new(BIN.as_os_str())
+        .arg("start")
+        .arg("-c")
+        .arg(config.filename())
+        .arg("--db")
+        .arg(&proc_info.db_path)
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let proc_guard = ChildGuard::new(homestar_proc);
+
+    if wait_for_socket_connection_v6(rpc_port, 1000).is_err() {
+        panic!("Homestar server/runtime failed to start in time");
+    }
+
+    let dead_proc = kill_homestar(proc_guard.take(), None);
+    let stdout = retrieve_output(dead_proc);
+
+    let multiaddr_not_supported =
+        check_for_line_with(stdout.clone(), vec!["MultiaddrNotSupported"]);
+    // let bootstrapped =
+    //     check_for_line_with(stdout.clone(), vec![""]);
+
+    // This can connect to known dns multiaddrs, but won't over GHA.
+    // let connected_to_known_peer =
+    //     check_for_line_with(stdout, vec!["peer connection established", known_peer_id]);
+    // assert!(connected_to_known_peer);
+
+    // Check that we don't receive a MultiaddrNotSupported error.
+    assert!(!multiaddr_not_supported);
 
     Ok(())
 }

--- a/homestar-runtime/tests/network.rs
+++ b/homestar-runtime/tests/network.rs
@@ -636,8 +636,6 @@ fn test_libp2p_configured_with_known_dns_multiaddr() -> Result<()> {
 
     let multiaddr_not_supported =
         check_for_line_with(stdout.clone(), vec!["MultiaddrNotSupported"]);
-    // let bootstrapped =
-    //     check_for_line_with(stdout.clone(), vec![""]);
 
     // This can connect to known dns multiaddrs, but won't over GHA.
     // let connected_to_known_peer =

--- a/homestar-runtime/tests/network/dht.rs
+++ b/homestar-runtime/tests/network/dht.rs
@@ -194,7 +194,6 @@ fn test_libp2p_dht_records_integration() -> Result<()> {
             .arg("run")
             .arg("-p")
             .arg(rpc_port1.to_string())
-            .arg("-w")
             .arg("tests/fixtures/test-workflow-add-one-part-one.json")
             .output();
 
@@ -251,7 +250,6 @@ fn test_libp2p_dht_records_integration() -> Result<()> {
         //     .arg("run")
         //     .arg("-p")
         //     .arg(rpc_port2.to_string())
-        //     .arg("-w")
         //     .arg("tests/fixtures/test-workflow-add-one-part-two.json")
         //     .output();
 
@@ -280,7 +278,6 @@ fn test_libp2p_dht_records_integration() -> Result<()> {
             .arg("run")
             .arg("-p")
             .arg(rpc_port2.to_string())
-            .arg("-w")
             .arg("tests/fixtures/test-workflow-add-one-part-one.json")
             .output();
 
@@ -509,7 +506,6 @@ fn test_libp2p_dht_quorum_failure_intregration() -> Result<()> {
             .arg("run")
             .arg("-p")
             .arg(rpc_port1.to_string())
-            .arg("-w")
             .arg("tests/fixtures/test-workflow-add-one.json")
             .output();
 
@@ -728,7 +724,6 @@ fn test_libp2p_dht_workflow_info_provider_integration() -> Result<()> {
             .arg("run")
             .arg("-p")
             .arg(rpc_port1.to_string())
-            .arg("-w")
             .arg("tests/fixtures/test-workflow-add-one.json")
             .output();
 
@@ -745,7 +740,6 @@ fn test_libp2p_dht_workflow_info_provider_integration() -> Result<()> {
             .arg("run")
             .arg("-p")
             .arg(rpc_port2.to_string())
-            .arg("-w")
             .arg("tests/fixtures/test-workflow-add-one.json")
             .output();
 
@@ -1133,7 +1127,6 @@ fn test_libp2p_dht_workflow_info_provider_recursive_integration() -> Result<()> 
             .arg("run")
             .arg("-p")
             .arg(rpc_port1.to_string())
-            .arg("-w")
             .arg("tests/fixtures/test-workflow-add-one.json")
             .output();
 
@@ -1163,7 +1156,6 @@ fn test_libp2p_dht_workflow_info_provider_recursive_integration() -> Result<()> 
             .arg("run")
             .arg("-p")
             .arg(rpc_port2.to_string())
-            .arg("-w")
             .arg("tests/fixtures/test-workflow-add-one.json")
             .output();
 
@@ -1211,7 +1203,6 @@ fn test_libp2p_dht_workflow_info_provider_recursive_integration() -> Result<()> 
             .arg("run")
             .arg("-p")
             .arg(rpc_port3.to_string())
-            .arg("-w")
             .arg("tests/fixtures/test-workflow-add-one.json")
             .output();
 

--- a/homestar-runtime/tests/network/gossip.rs
+++ b/homestar-runtime/tests/network/gossip.rs
@@ -176,7 +176,6 @@ fn test_libp2p_receipt_gossip_integration() -> Result<()> {
             .arg("run")
             .arg("-p")
             .arg(rpc_port1.to_string())
-            .arg("-w")
             .arg("tests/fixtures/test-workflow-add-one.json")
             .output();
 

--- a/homestar-workspace-hack/Cargo.toml
+++ b/homestar-workspace-hack/Cargo.toml
@@ -211,6 +211,7 @@ iana-time-zone = { version = "0.1", default-features = false, features = ["fallb
 object = { version = "0.32", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
 ring = { version = "0.17", features = ["std"] }
 rustix = { version = "0.38", features = ["event", "mm", "net", "param", "process", "procfs", "termios", "time"] }
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 subtle = { version = "2" }
 
 [target.x86_64-apple-darwin.build-dependencies]
@@ -219,6 +220,7 @@ iana-time-zone = { version = "0.1", default-features = false, features = ["fallb
 object = { version = "0.32", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
 ring = { version = "0.17", features = ["std"] }
 rustix = { version = "0.38", features = ["event", "mm", "net", "param", "process", "procfs", "termios", "time"] }
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 subtle = { version = "2" }
 
 [target.aarch64-apple-darwin.dependencies]
@@ -227,6 +229,7 @@ iana-time-zone = { version = "0.1", default-features = false, features = ["fallb
 object = { version = "0.32", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
 ring = { version = "0.17", features = ["std"] }
 rustix = { version = "0.38", features = ["event", "mm", "net", "param", "process", "procfs", "termios", "time"] }
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 subtle = { version = "2" }
 
 [target.aarch64-apple-darwin.build-dependencies]
@@ -235,6 +238,7 @@ iana-time-zone = { version = "0.1", default-features = false, features = ["fallb
 object = { version = "0.32", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
 ring = { version = "0.17", features = ["std"] }
 rustix = { version = "0.38", features = ["event", "mm", "net", "param", "process", "procfs", "termios", "time"] }
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 subtle = { version = "2" }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
@@ -244,6 +248,7 @@ linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", 
 object = { version = "0.32", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
 ring = { version = "0.17", features = ["std"] }
 rustix = { version = "0.38", features = ["event", "mm", "net", "param", "process", "procfs", "termios", "thread", "time"] }
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 subtle = { version = "2" }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
@@ -253,6 +258,7 @@ linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", 
 object = { version = "0.32", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
 ring = { version = "0.17", features = ["std"] }
 rustix = { version = "0.38", features = ["event", "mm", "net", "param", "process", "procfs", "termios", "thread", "time"] }
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 subtle = { version = "2" }
 
 [target.x86_64-unknown-linux-musl.dependencies]
@@ -262,6 +268,7 @@ linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", 
 object = { version = "0.32", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
 ring = { version = "0.17", features = ["std"] }
 rustix = { version = "0.38", features = ["event", "mm", "net", "param", "process", "procfs", "termios", "thread", "time"] }
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 subtle = { version = "2" }
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
@@ -271,6 +278,7 @@ linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", 
 object = { version = "0.32", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
 ring = { version = "0.17", features = ["std"] }
 rustix = { version = "0.38", features = ["event", "mm", "net", "param", "process", "procfs", "termios", "thread", "time"] }
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 subtle = { version = "2" }
 
 [target.aarch64-unknown-linux-musl.dependencies]
@@ -280,6 +288,7 @@ linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", 
 object = { version = "0.32", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
 ring = { version = "0.17", features = ["std"] }
 rustix = { version = "0.38", features = ["event", "mm", "net", "param", "process", "procfs", "termios", "thread", "time"] }
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 subtle = { version = "2" }
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
@@ -289,6 +298,7 @@ linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", 
 object = { version = "0.32", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
 ring = { version = "0.17", features = ["std"] }
 rustix = { version = "0.38", features = ["event", "mm", "net", "param", "process", "procfs", "termios", "thread", "time"] }
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 subtle = { version = "2" }
 
 ### END HAKARI SECTION

--- a/homestar-workspace-hack/Cargo.toml
+++ b/homestar-workspace-hack/Cargo.toml
@@ -57,6 +57,7 @@ jsonrpsee-core = { version = "0.21", features = ["async-client", "async-wasm-cli
 libc = { version = "0.2", features = ["extra_traits"] }
 libsecp256k1-core = { version = "0.3" }
 libsqlite3-sys = { version = "0.27", features = ["bundled"] }
+memchr = { version = "2" }
 miette = { version = "5", features = ["fancy"] }
 miniz_oxide = { version = "0.7", features = ["simd"] }
 multibase = { version = "0.9" }
@@ -68,12 +69,13 @@ regex-syntax = { version = "0.8" }
 retry = { version = "2" }
 rustc-hash = { version = "1" }
 scopeguard = { version = "1" }
+semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1", features = ["alloc", "float_roundtrip", "raw_value"] }
+serde_json = { version = "1", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sha2 = { version = "0.10" }
 signature = { version = "2", default-features = false, features = ["std"] }
 smallvec = { version = "1", default-features = false, features = ["union"] }
-time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "rt-multi-thread", "signal", "test-util", "tracing"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io", "time"] }
@@ -134,6 +136,7 @@ jsonrpsee-core = { version = "0.21", features = ["async-client", "async-wasm-cli
 libc = { version = "0.2", features = ["extra_traits"] }
 libsecp256k1-core = { version = "0.3" }
 libsqlite3-sys = { version = "0.27", features = ["bundled"] }
+memchr = { version = "2" }
 miette = { version = "5", features = ["fancy"] }
 miniz_oxide = { version = "0.7", features = ["simd"] }
 multibase = { version = "0.9" }
@@ -146,14 +149,15 @@ regex-syntax = { version = "0.8" }
 retry = { version = "2" }
 rustc-hash = { version = "1" }
 scopeguard = { version = "1" }
+semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1", features = ["alloc", "float_roundtrip", "raw_value"] }
+serde_json = { version = "1", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sha2 = { version = "0.10" }
 signature = { version = "2", default-features = false, features = ["std"] }
 smallvec = { version = "1", default-features = false, features = ["union"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "full", "visit"] }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "rt-multi-thread", "signal", "test-util", "tracing"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io", "time"] }


### PR DESCRIPTION
fix: add handling of dns multiaddrs and added kad bootstrapping

Closes #545.
Closes #492. 

refactor: transport handling for ws & quic as fallback

Includes:
- dns fallback to cloudflare
- CLI: removal of -w for running workflows; it's now a positional argument (the first one on run)
  * related to https://github.com/ipvm-wg/homestar/issues/489
- CLI: `node` command which showcases nodeinfo, e.g. peer_id and listener addrs/connections
  * related to https://github.com/ipvm-wg/homestar/issues/489
- CLI: adds static/non-RPC `info` command showcasing version, build-git-sha, and features built with. We can extend this later with more build information. 
- Closes https://github.com/ipvm-wg/homestar/issues/297
- Closes https://github.com/ipvm-wg/homestar/issues/497