### PR TITLE
fix: Update nonce schema with IPLD bytes

### DIFF
--- a/homestar-runtime/src/runner/file.rs
+++ b/homestar-runtime/src/runner/file.rs
@@ -116,4 +116,26 @@ mod test {
             workflow_file.validate_and_parse().await.unwrap();
         assert_eq!(workflow, newly_validated_workflow);
     }
+
+    #[tokio::test]
+    async fn validate_and_parse_workflow_with_nonce() {
+        let path = PathBuf::from("./fixtures/test_nonce.json");
+        let config = Resources::default();
+        let (instruction, _) = test_utils::wasm_instruction_with_nonce::<Arg>();
+
+        let task = Task::new(
+            RunInstruction::Expanded(instruction.clone()),
+            config.clone().into(),
+            UcanPrf::default(),
+        );
+
+        let workflow = Workflow::new(vec![task]);
+
+        workflow.to_file(path.display().to_string()).unwrap();
+        let workflow_file = ReadWorkflow { file: path.clone() };
+
+        let (validated_workflow, _settings) = workflow_file.validate_and_parse().await.unwrap();
+
+        assert_eq!(workflow, validated_workflow);
+    }
 }


### PR DESCRIPTION
# Description

This PR makes the following changes:

- [x] Update the nonce schema one of IPLD bytes or empty string
- [x] Add workflow validation test that uses a nonce

The schema will be updated by the schemas action, but as a preview it looks like this:

```json
"nnc": {
  "description": "A 12-byte or 16-byte nonce encoded as IPLD bytes. Use empty string for no nonce.",
  "oneOf": [
    {
      "$ref": "#/definitions/ipld_bytes"
    },
    {
      "type": "string",
      "const": ""
    }
  ]
},
```
```json
"ipld_bytes": {
  "title": "IPLD bytes",
  "description": "Base64 encoded binary",
  "type": "object",
  "properties": {
    "/": {
      "type": "object",
      "properties": {
        "bytes": {
          "type": "string"
        }
      }
    }
  }
},
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] This change requires a documentation update (schemas will be updated by the action)

## Test plan (required)

A new `validate_and_parse_workflow_with_nonce` has been added that validates a workflow with a task that uses a nonce.
