### PR TITLE
refactor: Add workflow spans and every cli logging

### DIFF
--- a/homestar-runtime/src/logger.rs
+++ b/homestar-runtime/src/logger.rs
@@ -7,6 +7,7 @@ use tracing_subscriber::{layer::SubscriberExt as _, prelude::*, EnvFilter};
 
 const LOG_FILE: &str = "homestar.log";
 const DIRECTIVE_EXPECT: &str = "Invalid tracing directive";
+const EVERY_CLI: &str = "EVERY_CLI";
 
 /// Logger interface.
 #[derive(Debug)]
@@ -44,7 +45,7 @@ fn init(
     #[allow(unused_variables)] settings: &settings::Monitoring,
 ) -> WorkerGuard {
     // RUST_LOG ignored when EVERY_CLI is true
-    let every_cli = std::env::var("EVERY_CLI").is_ok_and(|val| val == "true");
+    let every_cli: bool = std::env::var(EVERY_CLI).is_ok_and(|val| val == "true");
 
     // TODO: Add support for customizing logger(s) / specialzed formatters.
     let format_layer = if every_cli {

--- a/homestar-runtime/src/logger.rs
+++ b/homestar-runtime/src/logger.rs
@@ -7,6 +7,7 @@ use tracing_subscriber::{layer::SubscriberExt as _, prelude::*, EnvFilter};
 
 const LOG_FILE: &str = "homestar.log";
 const DIRECTIVE_EXPECT: &str = "Invalid tracing directive";
+// Sets simplified logging filter and format for Every CLI
 const EVERY_CLI: &str = "EVERY_CLI";
 
 /// Logger interface.

--- a/homestar-runtime/src/logger.rs
+++ b/homestar-runtime/src/logger.rs
@@ -73,6 +73,11 @@ fn init(
     let filter = if every_cli {
         EnvFilter::new("off")
             .add_directive(
+                "homestar_runtime::runner[run_worker]=info"
+                    .parse()
+                    .expect(DIRECTIVE_EXPECT),
+            )
+            .add_directive(
                 "homestar_runtime::worker[run]=info"
                     .parse()
                     .expect(DIRECTIVE_EXPECT),

--- a/homestar-runtime/src/logger.rs
+++ b/homestar-runtime/src/logger.rs
@@ -81,6 +81,11 @@ fn init(
                     .parse()
                     .expect(DIRECTIVE_EXPECT),
             )
+            .add_directive(
+                "homestar_wasm[wasi_log]=trace"
+                    .parse()
+                    .expect(DIRECTIVE_EXPECT),
+            )
     } else {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| {
             EnvFilter::new("info")

--- a/homestar-runtime/src/logger.rs
+++ b/homestar-runtime/src/logger.rs
@@ -77,7 +77,7 @@ fn init(
                     .expect(DIRECTIVE_EXPECT),
             )
             .add_directive(
-                "homestar_runtime::worker[spawn_tasks]=info"
+                "homestar_runtime::worker[spawn_workflow_tasks]=info"
                     .parse()
                     .expect(DIRECTIVE_EXPECT),
             )

--- a/homestar-runtime/src/tasks/wasm.rs
+++ b/homestar-runtime/src/tasks/wasm.rs
@@ -8,6 +8,7 @@ use homestar_wasm::{
     io::{Arg, Output},
     wasmtime::{world::Env, Error as WasmRuntimeError, State, World},
 };
+use tracing::Instrument;
 
 #[allow(dead_code)]
 #[allow(missing_debug_implementations)]
@@ -32,7 +33,7 @@ impl WasmContext {
         args: Args<Arg>,
     ) -> Result<Output, WasmRuntimeError> {
         let env = World::instantiate_with_current_env(bytes, fun_name, &mut self.env).await?;
-        env.execute(args).await
+        env.execute(args).in_current_span().await
     }
 }
 

--- a/homestar-runtime/src/worker.rs
+++ b/homestar-runtime/src/worker.rs
@@ -36,7 +36,7 @@ use indexmap::IndexMap;
 use libipld::{Cid, Ipld};
 use std::{collections::BTreeMap, sync::Arc};
 use tokio::task::JoinSet;
-use tracing::{debug, error, info, info_span, instrument, Instrument};
+use tracing::{debug, debug_span, error, info, info_span, instrument, Instrument};
 
 mod poller;
 mod resolver;
@@ -357,7 +357,7 @@ where
                              match resolved.await {
                                 Ok(inst_result) => {
                                     match wasm_ctx.run(wasm, &fun, inst_result).instrument({
-                                        info_span!("wasm_run").or_current()
+                                        debug_span!("wasm_run").or_current()
                                     }).await {
                                         Ok(output) => Ok((
                                             output,

--- a/homestar-runtime/src/worker.rs
+++ b/homestar-runtime/src/worker.rs
@@ -459,6 +459,13 @@ where
                     "committed to database"
                 );
 
+                info!(
+                    subject = "worker.receipt",
+                    category = "worker.run",
+                    receipt_cid = stored_receipt.cid().to_string(),
+                    "computed receipt"
+                );
+
                 let _ = self
                     .event_sender
                     .send_async(Event::CapturedReceipt(Captured::with(

--- a/homestar-runtime/src/worker.rs
+++ b/homestar-runtime/src/worker.rs
@@ -385,7 +385,7 @@ where
                             }
                         }
                         .instrument({
-                            info_span!("spawn_tasks").or_current()
+                            info_span!("spawn_workflow_tasks").or_current()
                         }));
 
                         handles.push(handle);

--- a/homestar-runtime/src/worker/resolver.rs
+++ b/homestar-runtime/src/worker/resolver.rs
@@ -23,7 +23,7 @@ use tokio::{
     sync::RwLock,
     time::{timeout_at, Instant},
 };
-use tracing::debug;
+use tracing::{debug, instrument};
 
 pub(crate) trait Resolver {
     async fn resolve(
@@ -35,6 +35,7 @@ pub(crate) trait Resolver {
 }
 
 impl Resolver for Cid {
+    #[instrument(level = "debug", name = "cid_resolve", skip_all)]
     async fn resolve(
         self,
         linkmap: Arc<RwLock<LinkMap<task::Result<Arg>>>>,

--- a/homestar-wasm/src/wasmtime/host/helpers.rs
+++ b/homestar-wasm/src/wasmtime/host/helpers.rs
@@ -6,6 +6,7 @@ use crate::wasmtime::{
 };
 use async_trait::async_trait;
 use std::time::Instant;
+use tracing::instrument;
 
 #[async_trait]
 impl helpers::Host for State {
@@ -30,6 +31,7 @@ impl helpers::Host for State {
 #[async_trait]
 impl wasi::logging::logging::Host for State {
     /// Log a message, formatted by the runtime subscriber.
+    #[instrument(name = "wasi_log", skip_all)]
     async fn log(
         &mut self,
         level: wasi::logging::logging::Level,

--- a/homestar-wasm/src/wasmtime/world.rs
+++ b/homestar-wasm/src/wasmtime/world.rs
@@ -146,7 +146,7 @@ impl<T> Env<T> {
     /// Types must conform to [Wit] IDL types when Wasm was compiled/generated.
     ///
     /// [Wit]: <https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md>
-    #[instrument(name = "execute", skip_all)]
+    #[instrument(skip_all)]
     pub async fn execute(&mut self, args: Args<Arg>) -> Result<Output, Error>
     where
         T: Send,


### PR DESCRIPTION
# Description

This PR implements the following changes:

- [x] Add initial workflow and task execution spans
- [x] Add workflow initialize, start, and end logs
- [x] Add computed and replayed receipt logs
- [x] Add custom logging format and filter for EveryCLI
- [x] Minor re-wording of existing logs

## Link to issue

Implements spans needed in #457

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

Run Homestar with `EVERY_CLI` set to `true` to see the simplified logs:

```
EVERY_CLI=true cargo run -- start
```

Check that `RUST_LOG` works when `EVERY_CLI` is `false` or not set:

 ```
EVERY_CLI=false RUST_LOG=info cargo run -- start
```

## Screenshots

Running `test-workflow-add-one.json` with `EVERY_CLI` logs:

![CleanShot 2024-03-12 at 22 10 28@2x](https://github.com/ipvm-wg/homestar/assets/7957636/4ed317e7-d7ce-49b2-a83f-8886c29da942)

Same workflow, on replay:

![CleanShot 2024-03-12 at 22 12 12@2x](https://github.com/ipvm-wg/homestar/assets/7957636/287808b0-68ec-408f-a471-cef0186aeeab)

A different workflow with WASI logging at `trace` level:

![CleanShot 2024-03-12 at 22 17 42@2x](https://github.com/ipvm-wg/homestar/assets/7957636/f8353c83-f8b0-4c00-9e9f-51d114037739)

Error case where an arg with an unexpected type is passed to a workflow task:

![CleanShot 2024-03-12 at 22 14 17@2x](https://github.com/ipvm-wg/homestar/assets/7957636/0a19bb39-9f7e-4253-9ab9-db498364a9a1)


